### PR TITLE
Fixed collector core CMakeLists.txt

### DIFF
--- a/build/cmake/terrama2_mod_ws_collector_core/CMakeLists.txt
+++ b/build/cmake/terrama2_mod_ws_collector_core/CMakeLists.txt
@@ -24,6 +24,8 @@
 #  Author: Vinicius Camapanha
 #
 
+
+
 file(GLOB TERRAMA2_SRC_FILES ${TERRAMA2_ABSOLUTE_ROOT_DIR}/src/terrama2/ws/collector/core/*.cpp)
 file(GLOB TERRAMA2_HDR_FILES ${TERRAMA2_ABSOLUTE_ROOT_DIR}/src/terrama2/ws/collector/core/*.hpp)
 
@@ -50,7 +52,8 @@ qt5_use_modules(terrama2_mod_ws_collector_core Widgets)
 set_target_properties(terrama2_mod_ws_collector_core
                       PROPERTIES VERSION ${TERRAMA2_VERSION_MAJOR}.${TERRAMA2_VERSION_MINOR}
                                  SOVERSION ${TERRAMA2_VERSION_MAJOR}.${TERRAMA2_VERSION_MINOR}
-                                 INSTALL_NAME_DIR "@executable_path/../lib")
+                                 INSTALL_NAME_DIR "@executable_path/../lib"
+                                 LINKER_LANGUAGE "CXX")
 
 install(TARGETS terrama2_mod_ws_collector_core
         EXPORT terrama2-targets
@@ -61,4 +64,4 @@ install(TARGETS terrama2_mod_ws_collector_core
 install(FILES ${TERRAMA2_HDR_FILES}
         DESTINATION ${TERRAMA2_DESTINATION_HEADERS}/terrama2/ws/collector/core COMPONENT devel)
 
-#export(TARGETS terrama2_mod_ws_collector_core APPEND FILE ${CMAKE_BINARY_DIR}/terrama2-exports.cmake)
+export(TARGETS terrama2_mod_ws_collector_core APPEND FILE ${CMAKE_BINARY_DIR}/terrama2-exports.cmake)

--- a/build/cmake/terrama2_mod_ws_collector_core/CMakeLists.txt
+++ b/build/cmake/terrama2_mod_ws_collector_core/CMakeLists.txt
@@ -61,4 +61,4 @@ install(TARGETS terrama2_mod_ws_collector_core
 install(FILES ${TERRAMA2_HDR_FILES}
         DESTINATION ${TERRAMA2_DESTINATION_HEADERS}/terrama2/ws/collector/core COMPONENT devel)
 
-export(TARGETS terrama2_mod_ws_collector_core APPEND FILE ${CMAKE_BINARY_DIR}/terrama2-exports.cmake)
+#export(TARGETS terrama2_mod_ws_collector_core APPEND FILE ${CMAKE_BINARY_DIR}/terrama2-exports.cmake)

--- a/src/terrama2/ws/collector/client/Client.cpp
+++ b/src/terrama2/ws/collector/client/Client.cpp
@@ -51,8 +51,72 @@ int terrama2::ws::collector::Client::ping(std::string& answer)
 }
 
 
-int terrama2::ws::collector::Client::addDataProvider(terrama2::core::DataProvider data_provider)
+int terrama2::ws::collector::Client::addDataProvider(terrama2::core::DataProvider dataProvider)
 {
-//  wsClient_->addDataProvider();
+  wsClient_->addDataProvider(dataProvider);
+
   return 0;
+}
+
+
+int terrama2::ws::collector::Client::addDataset(DataSet struct_dataSet)
+{
+
+  return SOAP_OK;
+}
+
+
+int terrama2::ws::collector::Client::updateDataProvider(DataProvider struct_dataProvider)
+{
+
+  return SOAP_OK;
+}
+
+
+int terrama2::ws::collector::Client::updateDataSet(DataSet struct_dataSet)
+{
+
+  return SOAP_OK;
+}
+
+
+int terrama2::ws::collector::Client::removeDataProvider(uint64_t id)
+{
+
+  return SOAP_OK;
+}
+
+
+int terrama2::ws::collector::Client::removeDataSet(uint64_t id)
+{
+
+  return SOAP_OK;
+}
+
+
+int terrama2::ws::collector::Client::findDataProvider(uint64_t id, DataProvider &struct_dataProvider)
+{
+
+  return SOAP_OK;
+}
+
+
+int terrama2::ws::collector::Client::findDataSet(uint64_t id,DataSet &struct_dataSet)
+{
+
+  return SOAP_OK;
+}
+
+
+int terrama2::ws::collector::Client::listDataProvider(std::vector< DataProvider > &dataProviderList)
+{
+
+  return SOAP_OK;
+}
+
+
+int terrama2::ws::collector::Client::listDataSet(std::vector< DataSet > &dataSetList)
+{
+
+  return SOAP_OK;
 }

--- a/src/terrama2/ws/collector/client/Client.hpp
+++ b/src/terrama2/ws/collector/client/Client.hpp
@@ -39,6 +39,7 @@
 
 // TerraMA2
 #include "../../../core/DataProvider.hpp"
+#include "../../../core/DataSet.hpp"
 
 namespace terrama2
 {
@@ -59,7 +60,26 @@ namespace terrama2
 
           int ping(std::string& answer);
 
-          int addDataProvider(terrama2::core::DataProvider data_provider);
+          int addDataProvider(terrama2::core::DataProvider dataProvider);
+
+          int addDataset(DataSet struct_dataSet);
+
+          int updateDataProvider(DataProvider struct_dataProvider);
+
+          int updateDataSet(DataSet struct_dataSet);
+
+          int removeDataProvider(uint64_t id);
+
+          int removeDataSet(uint64_t id);
+
+          int findDataProvider(uint64_t id, DataProvider &struct_dataProvider);
+
+          int findDataSet(uint64_t id,DataSet &struct_dataSet);
+
+          int listDataProvider(std::vector< DataProvider > &dataProviderList);
+
+          int listDataSet(std::vector< DataSet > &dataSetList);
+
 
         private:
 

--- a/src/terrama2/ws/collector/core/Utils.hpp
+++ b/src/terrama2/ws/collector/core/Utils.hpp
@@ -59,21 +59,39 @@ namespace terrama2
       {
 
       /*!
-        \brief Method to convert a gSOAP struct DataProvider to a struct terrama2::core::DataProvider .
+        \brief Method to convert a gSOAP struct DataProvider to a terrama2::core::DataProviderPtr.
 
-        \param T1 MUST be a struct DataProvider, defined in soapStub.h(gSOAP generated file)
+        \param T1 MUST be a gSOAP struct DataSet, defined in soapStub.h(gSOAP generated file)
 
         \return terrama2::core::DataProvider that contains the data in gSOAP struct DataProvider passed.
       */
-        template<typename T1> terrama2::core::DataProviderPtr Struct2DataProviderPtr(T1);
+        template<typename T1> terrama2::core::DataProviderPtr Struct2DataProviderPtr(T1 struct_dataprovider);
 
+      /*!
+        \brief Method to convert a terrama2::core::DataProviderPtr to a gSOAP struct DataProvider.
 
-        template<typename T1, typename T2>  T2 DataProviderPtr2Struct(T1);
+        \param T1 MUST be a gSOAP struct DataSet, defined in soapStub.h(gSOAP generated file)
 
-        // VINICIUS: check if need to create a Struct2DataProviderPtr
+        \return a gSOAP struct DataProvider that contains the data in terrama2::core::DataProviderPtr passed.
+      */
+        template<typename T1> T1 DataProviderPtr2Struct(terrama2::core::DataProviderPtr dataproviderPtr);
 
+      /*!
+        \brief Method to convert a gSOAP struct DataSet to a terrama2::core::DataSetPtr.
+
+        \param T1 MUST be a gSOAP struct DataSet, defined in soapStub.h(gSOAP generated file)
+
+        \return terrama2::core::DataSetPtr that contains the data in gSOAP struct DataSet passed.
+      */
         template <typename T1> terrama2::core::DataSetPtr Struct2DataSetPtr(T1 struct_dataset);
 
+      /*!
+        \brief Method to convert a terrama2::core::DataProvider to a gSOAP struct DataProvider.
+
+        \param T1 MUST be a gSOAP struct DataSet, defined in soapStub.h(gSOAP generated file)
+
+        \return A gSOAP struct DataProvider that contains the data in terrama2::core::DataProvider passed.
+      */
         template<typename T1> T1 DataSetPtr2Struct(terrama2::core::DataSetPtr datasetPtr);
 
       }
@@ -81,48 +99,42 @@ namespace terrama2
   }
 }
 
+
 template <typename T1>
 terrama2::core::DataProviderPtr terrama2::ws::collector::core::Struct2DataProviderPtr(T1 struct_dataprovider)
 {
-  // VINICIUS: check if a DataProvider constructor that receives (id, name, kind) was implemented
-  //T2 dataprovider(struct_dataprovider.name, (terrama2::core::DataProvider::Kind)struct_dataprovider.kind, struct_dataprovider.id);
-  terrama2::core::DataProvider dataprovider(struct_dataprovider.name, (terrama2::core::DataProvider::Kind)struct_dataprovider.kind);
+  terrama2::core::DataProvider dataprovider(struct_dataprovider.name, (terrama2::core::DataProvider::Kind)struct_dataprovider.kind, struct_dataprovider.id);
 
   dataprovider.setDescription(struct_dataprovider.description);
   dataprovider.setUri(struct_dataprovider.uri);
   dataprovider.setStatus((terrama2::core::DataProvider::Status)struct_dataprovider.status);
 
   return std::make_shared<terrama2::core::DataProvider>(dataprovider);
-
 }
 
-template<typename T1, typename T2>
-T2 terrama2::ws::collector::core::DataProviderPtr2Struct(T1 dataproviderPtr)
-{
 
-  T2 struct_dataprovider = T2{
+template<typename T1>
+T1 terrama2::ws::collector::core::DataProviderPtr2Struct(terrama2::core::DataProviderPtr dataproviderPtr)
+{
+  T1 struct_dataprovider = T1{
       dataproviderPtr->id(),
       dataproviderPtr->name(),
       dataproviderPtr->description(),
-      (int)dataproviderPtr->kind(),
+      (uint32_t)dataproviderPtr->kind(),
       dataproviderPtr->uri(),
-      (int)dataproviderPtr->status()
+      (uint32_t)dataproviderPtr->status()
 };
 
   return struct_dataprovider;
 }
 
 
-
 template <typename T1>
 terrama2::core::DataSetPtr terrama2::ws::collector::core::Struct2DataSetPtr(T1 struct_dataset)
 {
-
   auto dataproviderPtr = terrama2::core::DataManager::getInstance().findDataProvider(struct_dataset.id);
 
-  // VINICIUS: check if the constructor accept the id parameter already
-  //terrama2::core::DataSet dataset(dataproviderPtr, struct_dataset.name, (terrama2::core::DataSet::Kind)struct_dataset.kind, struct_dataset.id);
-  terrama2::core::DataSet dataset(dataproviderPtr, struct_dataset.name, (terrama2::core::DataSet::Kind)struct_dataset.kind);
+  terrama2::core::DataSet dataset(dataproviderPtr, struct_dataset.name, (terrama2::core::DataSet::Kind)struct_dataset.kind, struct_dataset.id);
 
   dataset.setDescription(struct_dataset.description);
   dataset.setStatus((terrama2::core::DataSet::Status)struct_dataset.status);
@@ -158,7 +170,6 @@ T1 terrama2::ws::collector::core::DataSetPtr2Struct(terrama2::core::DataSetPtr d
   struct_dataset.schedule_timeout = datasetPtr->scheduleTimeout().toString();
 
   return struct_dataset;
-
 }
 
 #endif // __TERRAMA2_WS_COLLECTOR_CORE_UTILS_HPP__

--- a/src/terrama2/ws/collector/core/Utils.hpp
+++ b/src/terrama2/ws/collector/core/Utils.hpp
@@ -65,10 +65,10 @@ namespace terrama2
 
         \return terrama2::core::DataProvider that contains the data in gSOAP struct DataProvider passed.
       */
-        template<typename T1, typename T2> T2 Struct2DataProvider(T1);
+        template<typename T1> terrama2::core::DataProviderPtr Struct2DataProviderPtr(T1);
 
 
-        template<typename T1, typename T2> T2 DataProviderPtr2Struct(T1);
+        template<typename T1, typename T2>  T2 DataProviderPtr2Struct(T1);
 
         // VINICIUS: check if need to create a Struct2DataProviderPtr
 
@@ -81,18 +81,18 @@ namespace terrama2
   }
 }
 
-template <typename T1, typename T2>
-T2 terrama2::ws::collector::core::Struct2DataProvider(T1 struct_dataprovider)
+template <typename T1>
+terrama2::core::DataProviderPtr terrama2::ws::collector::core::Struct2DataProviderPtr(T1 struct_dataprovider)
 {
   // VINICIUS: check if a DataProvider constructor that receives (id, name, kind) was implemented
   //T2 dataprovider(struct_dataprovider.name, (terrama2::core::DataProvider::Kind)struct_dataprovider.kind, struct_dataprovider.id);
-  T2 dataprovider(struct_dataprovider.name, (terrama2::core::DataProvider::Kind)struct_dataprovider.kind);
+  terrama2::core::DataProvider dataprovider(struct_dataprovider.name, (terrama2::core::DataProvider::Kind)struct_dataprovider.kind);
 
   dataprovider.setDescription(struct_dataprovider.description);
   dataprovider.setUri(struct_dataprovider.uri);
   dataprovider.setStatus((terrama2::core::DataProvider::Status)struct_dataprovider.status);
 
-  return dataprovider;
+  return std::make_shared<terrama2::core::DataProvider>(dataprovider);
 
 }
 
@@ -132,15 +132,12 @@ terrama2::core::DataSetPtr terrama2::ws::collector::core::Struct2DataSetPtr(T1 s
   boost::posix_time::time_duration scheduleRetry(boost::posix_time::duration_from_string(struct_dataset.schedule_retry));
   boost::posix_time::time_duration scheduleTimeout(boost::posix_time::duration_from_string(struct_dataset.schedule_timeout));
 
-
   dataset.setDataFrequency(te::dt::TimeDuration(dataFrequency));
   dataset.setSchedule(te::dt::TimeDuration(schedule));
   dataset.setScheduleRetry(te::dt::TimeDuration(scheduleRetry));
   dataset.setScheduleTimeout(te::dt::TimeDuration(scheduleTimeout));
 
-  auto datasetPtr = std::make_shared<terrama2::core::DataSet>(dataset);
-
-  return datasetPtr;
+  return std::make_shared<terrama2::core::DataSet>(dataset);
 }
 
 

--- a/src/terrama2/ws/collector/core/WebService.hpp
+++ b/src/terrama2/ws/collector/core/WebService.hpp
@@ -45,23 +45,6 @@
 int Web__ping(std::string &answer);
 
 // VINICIUS_TODO: write the methods documentation
-/*!
-  \brief
-
-  \param
-
-  \return
-*/
-int Web__restart(void);
-
-/*!
-  \brief
-
-  \param
-
-  \return
-*/
-int Web__shutdown(void);
 
 /*!
   \brief

--- a/src/terrama2/ws/collector/core/WebService.hpp
+++ b/src/terrama2/ws/collector/core/WebService.hpp
@@ -44,8 +44,8 @@
 */
 int Web__ping(std::string &answer);
 
-// VINICIUS_TODO: write the methods documentation
-
+// VINICIUS: write the methods documentation
+// VINICIUS: check if need to change the Synchronous One-Way Message methods to receive an answer
 /*!
   \brief
 

--- a/src/terrama2/ws/collector/server/WebService.cpp
+++ b/src/terrama2/ws/collector/server/WebService.cpp
@@ -62,9 +62,7 @@ int WebService::shutdown(void)
 int WebService::addDataProvider(DataProvider struct_dataprovider)
 {
 
-  auto DataProviderPtr = std::make_shared<terrama2::core::DataProvider>(terrama2::ws::collector::core::Struct2DataProvider<DataProvider, terrama2::core::DataProvider>(struct_dataprovider));
-
-  terrama2::core::DataManager::getInstance().add(DataProviderPtr);
+  terrama2::core::DataManager::getInstance().add(terrama2::ws::collector::core::Struct2DataProviderPtr<DataProvider>(struct_dataprovider));
 
   return SOAP_OK;
 }
@@ -82,10 +80,7 @@ int WebService::addDataset(DataSet struct_dataset)
 
 int WebService::updateDataProvider(DataProvider struct_dataprovider)
 {
-
-  auto DataProviderPtr = std::make_shared<terrama2::core::DataProvider>(terrama2::ws::collector::core::Struct2DataProvider<DataProvider, terrama2::core::DataProvider>(struct_dataprovider));
-
-  terrama2::core::DataManager::getInstance().update(DataProviderPtr);
+  terrama2::core::DataManager::getInstance().update(terrama2::ws::collector::core::Struct2DataProviderPtr<DataProvider>(struct_dataprovider));
 
   return SOAP_OK;
 }
@@ -115,7 +110,7 @@ int WebService::removeDataSet(uint64_t id)
 }
 
 
-int WebService::findDataProvider(uint64_t id, struct DataProvider &struct_dataprovider)
+int WebService::findDataProvider(uint64_t id, DataProvider &struct_dataprovider)
 {
   auto dataproviderPtr = terrama2::core::DataManager::getInstance().findDataProvider(id);
 
@@ -125,7 +120,7 @@ int WebService::findDataProvider(uint64_t id, struct DataProvider &struct_datapr
 }
 
 
-int WebService::findDataSet(uint64_t id, struct DataSet &struct_dataset)
+int WebService::findDataSet(uint64_t id,DataSet &struct_dataset)
 {
   auto datasetPtr = terrama2::core::DataManager::getInstance().findDataSet(id);
 
@@ -135,13 +130,13 @@ int WebService::findDataSet(uint64_t id, struct DataSet &struct_dataset)
 }
 
 
-int WebService::listDataProvider(std::vector< struct DataProvider > &data_provider_list)
+int WebService::listDataProvider(std::vector< DataProvider > &data_provider_list)
 {
   return SOAP_OK;
 }
 
 
-int WebService::listDataSet(std::vector< struct DataSet > &data_set_list)
+int WebService::listDataSet(std::vector< DataSet > &data_set_list)
 {
   return SOAP_OK;
 }

--- a/src/terrama2/ws/collector/server/WebService.cpp
+++ b/src/terrama2/ws/collector/server/WebService.cpp
@@ -39,6 +39,7 @@
 #include "soapWebService.h"
 #include "Web.nsmap"
 
+// VINICIUS Implement Error Handling in methods
 
 int WebService::ping(std::string &answer)
 {

--- a/src/terrama2/ws/collector/server/WebService.cpp
+++ b/src/terrama2/ws/collector/server/WebService.cpp
@@ -29,6 +29,7 @@
 
 // STL
 #include <memory>
+#include <vector>
 
 // TerraMA2
 #include "../core/Utils.hpp"
@@ -39,7 +40,6 @@
 #include "Web.nsmap"
 
 
-
 int WebService::ping(std::string &answer)
 {
   answer = "TerraMA2 pong!";
@@ -47,21 +47,8 @@ int WebService::ping(std::string &answer)
 }
 
 
-int WebService::restart(void)
-{
-  return SOAP_OK;
-}
-
-
-int WebService::shutdown(void)
-{
-  return SOAP_OK;
-}
-
-
 int WebService::addDataProvider(DataProvider struct_dataprovider)
 {
-
   terrama2::core::DataManager::getInstance().add(terrama2::ws::collector::core::Struct2DataProviderPtr<DataProvider>(struct_dataprovider));
 
   return SOAP_OK;
@@ -114,7 +101,7 @@ int WebService::findDataProvider(uint64_t id, DataProvider &struct_dataprovider)
 {
   auto dataproviderPtr = terrama2::core::DataManager::getInstance().findDataProvider(id);
 
-  struct_dataprovider = terrama2::ws::collector::core::DataProviderPtr2Struct<terrama2::core::DataProviderPtr, DataProvider>(dataproviderPtr);
+  struct_dataprovider = terrama2::ws::collector::core::DataProviderPtr2Struct<DataProvider>(dataproviderPtr);
 
   return SOAP_OK;
 }
@@ -132,11 +119,25 @@ int WebService::findDataSet(uint64_t id,DataSet &struct_dataset)
 
 int WebService::listDataProvider(std::vector< DataProvider > &data_provider_list)
 {
+  std::vector<terrama2::core::DataProviderPtr> dataproviders = terrama2::core::DataManager::getInstance().providers();
+
+  for(uint32_t i = 0; i < dataproviders.size() ; i++)
+  {
+    data_provider_list.push_back(terrama2::ws::collector::core::DataProviderPtr2Struct<DataProvider>(dataproviders.at(i)));
+  }
+
   return SOAP_OK;
 }
 
 
 int WebService::listDataSet(std::vector< DataSet > &data_set_list)
 {
+  std::vector<terrama2::core::DataSetPtr> datasets = terrama2::core::DataManager::getInstance().dataSets();
+
+  for(uint32_t i = 0; i < datasets.size() ; i++)
+  {
+    data_set_list.push_back(terrama2::ws::collector::core::DataSetPtr2Struct<DataSet>(datasets.at(i)));
+  }
+
   return SOAP_OK;
 }


### PR DESCRIPTION
Solved error "CMake can not determine linker language for target".
When default, the linker language is setted the language of the files in the library (source files), as there aren't source files in the terrama2_ws_collector_core, the property was passed in "set_target_properties".