### PR TITLE
Reviewing creation / destruction of objects in the Data FTP Retrieve using the technique RAII

### DIFF
--- a/src/terrama2/collector/CurlOpener.cpp
+++ b/src/terrama2/collector/CurlOpener.cpp
@@ -1,0 +1,58 @@
+/*
+  Copyright (C) 2007 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of TerraMA2 - a free and open source computational
+  platform for analysis, monitoring, and alert of geo-environmental extremes.
+
+  TerraMA2 is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License,
+  or (at your option) any later version.
+
+  TerraMA2 is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with TerraMA2. See LICENSE. If not, write to
+  TerraMA2 Team at <terrama2-team@dpi.inpe.br>.
+*/
+
+/*!
+  \file terrama2/collector/CurlOpener.cpp
+
+  \brief
+
+ \author Evandro Delatin
+*/
+
+// TerraMA2
+#include "CurlOpener.hpp" 
+
+// Libcurl
+#include <curl/curl.h>
+
+
+terrama2::collector::CurlOpener::CurlOpener()
+{
+  curl_ = curl_easy_init();
+}
+
+
+void terrama2::collector::CurlOpener::init()
+{
+  curl_easy_cleanup(curl_);
+  curl_ = curl_easy_init();
+}
+
+
+CURL* terrama2::collector::CurlOpener::fcurl() const
+{
+  return curl_;
+}
+
+terrama2::collector::CurlOpener::~CurlOpener()
+{
+  curl_easy_cleanup(curl_);
+}

--- a/src/terrama2/collector/CurlOpener.hpp
+++ b/src/terrama2/collector/CurlOpener.hpp
@@ -1,0 +1,66 @@
+/*
+  Copyright (C) 2007 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of TerraMA2 - a free and open source computational
+  platform for analysis, monitoring, and alert of geo-environmental extremes.
+
+  TerraMA2 is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License,
+  or (at your option) any later version.
+
+  TerraMA2 is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with TerraMA2. See LICENSE. If not, write to
+  TerraMA2 Team at <terrama2-team@dpi.inpe.br>.
+*/
+
+/*!
+  \file terrama2/collector/CurlOpener.hpp
+
+  \brief
+
+ \author Evandro Delatin
+*/
+
+
+#ifndef __TERRAMA2_COLLECTOR_CURLOPENER_HPP__
+#define __TERRAMA2_COLLECTOR_CURLOPENER_HPP__
+
+
+// Libcurl
+#include <curl/curl.h>
+
+/*!
+     * \brief The CurlOpener class implements the RAII technique to control operations with Curl.
+     *     
+*/
+
+
+namespace terrama2
+{
+  namespace collector
+  {
+    class CurlOpener
+    {
+      public:
+
+       CurlOpener();
+
+       void init();
+  
+       CURL* fcurl() const;
+
+       ~CurlOpener();
+
+      private:
+        CURL* curl_;   
+     };
+  }
+}
+    
+#endif //__TERRAMA2_COLLECTOR_CURLOPENER_HPP__

--- a/src/terrama2/collector/DataRetrieverFTP.hpp
+++ b/src/terrama2/collector/DataRetrieverFTP.hpp
@@ -58,7 +58,7 @@ namespace terrama2
     {
     public:
       //! Constructor
-      explicit DataRetrieverFTP(const core::DataProvider& dataprovider);
+      explicit DataRetrieverFTP(const core::DataProvider& dataprovider, const std::string localization = "file://", const std::string folder = "/tmp/");
 
       virtual void open() override;
       virtual bool isOpen() override;
@@ -72,6 +72,8 @@ namespace terrama2
     private:
       CURL* curl_;
       std::vector<std::string> vectorNames_;
+      std::string localization_;
+      std::string folder_;
     };
 
     typedef std::shared_ptr<DataRetriever> DataRetrieverPtr;

--- a/src/terrama2/collector/FileOpener.cpp
+++ b/src/terrama2/collector/FileOpener.cpp
@@ -1,0 +1,60 @@
+/*
+  Copyright (C) 2007 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of TerraMA2 - a free and open source computational
+  platform for analysis, monitoring, and alert of geo-environmental extremes.
+
+  TerraMA2 is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License,
+  or (at your option) any later version.
+
+  TerraMA2 is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with TerraMA2. See LICENSE. If not, write to
+  TerraMA2 Team at <terrama2-team@dpi.inpe.br>.
+*/
+
+/*!
+  \file terrama2/collector/FileOpener.cpp
+
+  \brief
+
+ \author Evandro Delatin
+*/
+
+// STL
+#include <memory>
+#include <cassert>
+
+// TerraMA2
+#include "FileOpener.hpp" 
+
+
+terrama2::collector::FileOpener::FileOpener(const char* filename, const char* attribute)
+{
+  file_ = std::fopen(filename, attribute);
+
+  if (!file_)
+    throw std::runtime_error{"Unable to open the file"};
+}
+
+terrama2::collector::FileOpener::FileOpener(std::FILE* newfile)
+{
+  file_ = newfile;
+}
+
+terrama2::collector::FileOpener::~FileOpener()
+{
+  if (file_)
+    std::fclose(file_);
+}
+
+std::FILE* terrama2::collector::FileOpener::file() const
+{
+  return file_;
+}

--- a/src/terrama2/collector/FileOpener.hpp
+++ b/src/terrama2/collector/FileOpener.hpp
@@ -1,0 +1,65 @@
+/*
+  Copyright (C) 2007 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of TerraMA2 - a free and open source computational
+  platform for analysis, monitoring, and alert of geo-environmental extremes.
+
+  TerraMA2 is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License,
+  or (at your option) any later version.
+
+  TerraMA2 is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with TerraMA2. See LICENSE. If not, write to
+  TerraMA2 Team at <terrama2-team@dpi.inpe.br>.
+*/
+
+/*!
+  \file terrama2/collector/FileOpener.hpp
+
+  \brief
+
+ \author Evandro Delatin
+*/
+
+
+#ifndef __TERRAMA2_COLLECTOR_FILEOPENER_HPP__
+#define __TERRAMA2_COLLECTOR_FILEOPENER_HPP__
+
+// STL
+#include <memory>
+#include <cassert>
+
+/*!
+     * \brief The FileOpener class implements the RAII technique to control file operations.
+     *
+*/
+
+
+namespace terrama2
+{
+  namespace collector
+  {
+    class FileOpener
+    {
+      public:
+        FileOpener(const char* filename, const char* attribute);
+
+        FileOpener(std::FILE* newfile);
+
+        std::FILE* file() const;
+
+        ~FileOpener();
+
+       private:
+         std::FILE* file_;
+    };
+  }
+}
+
+#endif //__TERRAMA2_COLLECTOR_FILEOPENER_HPP__

--- a/src/terrama2/gui/admin/AdminApp.cpp
+++ b/src/terrama2/gui/admin/AdminApp.cpp
@@ -264,7 +264,7 @@ void AdminApp::newRequested()
     enableFields(true);
 
     nameConfig_ = newname;
-
+// Checks if the project already exists in the ListWidget
     ok = searchDataList(pimpl_->ui_->configListWidget->count(), newname);
 
     if (ok)
@@ -279,9 +279,12 @@ void AdminApp::newRequested()
     }
     else
     {
+      newData_ = false;
+      dataChanged_ = false;
       QMessageBox::information(this, tr("TerraMA2"), tr("Configuration Name Exists!"));
-      clearDataChanged();
-      enableFields(false);
+      auto items = pimpl_->ui_->configListWidget->findItems(configManager_->getDatabase()->name_, Qt::MatchExactly);
+      pimpl_->ui_->configListWidget->setCurrentItem(items[0]);
+      itemClicked();
     }
   }
 }
@@ -308,7 +311,7 @@ void AdminApp::openRequested()
     nameConfig_ = info.baseName();
 
 // Checks if the project already exists in the ListWidget
-    auto status = pimpl_->ui_->configListWidget->findItems(nameConfig_, Qt::MatchContains);
+    auto status = pimpl_->ui_->configListWidget->findItems(configManager_->getDatabase()->name_, Qt::MatchContains);
     if (status.size() > 0)
       return;
 
@@ -498,6 +501,8 @@ void AdminApp::cancelRequested()
 // Create Database
 void AdminApp::dbCreateDatabaseRequested()
 {
+  QApplication::setOverrideCursor(Qt::WaitCursor);
+  qApp->processEvents();
 
   try
   {
@@ -518,8 +523,6 @@ void AdminApp::dbCreateDatabaseRequested()
                                                                         database->password_.toStdString(),
                                                                         database->host_.toStdString(),
                                                                         database->port_ );
-
-   QMessageBox::information(this, tr("TerraMA2"), tr("Database created successfully!"));   
   }
 
   catch(const terrama2::Exception& e)
@@ -557,9 +560,11 @@ void AdminApp::dbCreateDatabaseRequested()
 
   catch(...)
   {
-    throw;
+    //TODO: log
   }
 
+  dbCheckConnectionRequested();
+  QApplication::restoreOverrideCursor();
 }
 
 // Check connection Database
@@ -616,7 +621,7 @@ void AdminApp::dbCheckConnectionRequested()
 
   catch(...)
   {
-    throw;
+    //TODO: log
   }
 
 }

--- a/src/terrama2/gui/admin/AdminApp.hpp
+++ b/src/terrama2/gui/admin/AdminApp.hpp
@@ -66,7 +66,7 @@ class AdminApp : public QMainWindow, private boost::noncopyable
 //! Fill fields
     void fillForm();
 
-   // void save(const QString command = "", const QString parameters = "", const ConfigManager& newdata);
+//! It saves current data
     void save();
 
     ConfigManager* getConfigManager();
@@ -75,7 +75,6 @@ signals:
 
 protected:
     void closeEvent(QCloseEvent* close);
-
 
   private slots:
 


### PR DESCRIPTION
Ticket #212:
- curl_easy_cleanup not being done everywhere;
- vectorNames_ is being cleaned with a clear, must verify that the files were low and remove if applicable;
- curl is not being cleaned or released:
  - use RAII
- destfilepath not being closed:
  -  use RAII
- the folder "/ tmp" can not be used this way, it will be different on each operating system. use a string for easy maintenance.

adjustments in the administration module:
- Do not open the same project more than once;
- Moving the mouse to hourglass when creating a database.