### PR TITLE
Review methods const in Mock

### DIFF
--- a/src/unittest/core/MockDataRetriever.hpp
+++ b/src/unittest/core/MockDataRetriever.hpp
@@ -42,9 +42,9 @@ class MockDataRetriever: public terrama2::core::DataRetriever
 
     MOCK_METHOD2(retrieveData,std::string(const std::string& query, const terrama2::core::Filter& filter));
 
-    MOCK_METHOD0(lastDateTime,te::dt::TimeInstantTZ());
+    MOCK_CONST_METHOD0(lastDateTime,te::dt::TimeInstantTZ());
 
-    MOCK_METHOD0(isRetrivable,bool());
+    MOCK_CONST_METHOD0(isRetrivable,bool());
 
     static terrama2::core::DataRetriever* makeMockDataRetriever(terrama2::core::DataProviderPtr dataProvider, MockDataRetriever * mock)
     {

--- a/src/unittest/core/TsDataAccessorDcpInpe.cpp
+++ b/src/unittest/core/TsDataAccessorDcpInpe.cpp
@@ -21,6 +21,15 @@
   \author Evandro Delatin
 */
 
+//terralib
+#include <terralib/dataaccess/datasource/DataSourceFactory.h>
+#include <terralib/dataaccess/datasource/DataSourceTransactor.h>
+#include <terralib/dataaccess/dataset/DataSetTypeConverter.h>
+#include <terralib/dataaccess/dataset/DataSetAdapter.h>
+#include <terralib/dataaccess/utils/Utils.h>
+#include <terralib/datatype/DateTimeProperty.h>
+#include <terralib/memory/DataSetItem.h>
+
 // TerraMA2
 #include <terrama2/core/Shared.hpp>
 #include <terrama2/core/utility/Utils.hpp>
@@ -35,6 +44,7 @@
 
 #include "TsDataAccessorDcpInpe.hpp"
 #include "MockDataRetriever.hpp"
+#include "MockDataSource.hpp"
 
 // QT
 #include <QObject>
@@ -280,6 +290,132 @@ void TsDataAccessorDcpInpe::TestFailDataRetrieverInvalid()
     auto makeMock = std::bind(MockDataRetriever::makeMockDataRetriever, std::placeholders::_1, mock_.get());
 
     RaiiTsDataAccessorDcpInpe("DCP-inpe",makeMock);
+
+    try
+    {
+      terrama2::core::DcpSeriesPtr dcpSeries = accessor.getDcpSeries(filter);
+    }
+    catch(const terrama2::Exception&)
+    {
+      QFAIL("Exception expected!");
+    }
+  }
+  catch(terrama2::Exception& e)
+  {
+    QFAIL(boost::get_error_info< terrama2::ErrorDescription >(e)->toStdString().c_str());
+  }
+
+  catch(...)
+  {
+    QFAIL("Unexpected exception!");
+  }
+
+  return;
+
+}
+
+void TsDataAccessorDcpInpe::TestDataSourceValid()
+{
+  try
+  {
+    //DataProvider information
+    terrama2::core::DataProvider* dataProvider = new terrama2::core::DataProvider();
+    terrama2::core::DataProviderPtr dataProviderPtr(dataProvider);
+    dataProvider->uri = "file://";
+    dataProvider->uri+=TERRAMA2_DATA_DIR;
+    dataProvider->uri+="/PCD_serrmar_INPE";
+
+    dataProvider->intent = terrama2::core::DataProviderIntent::COLLECTOR_INTENT;
+    dataProvider->dataProviderType = "FILE";
+    dataProvider->active = true;
+
+    //DataSeries information
+    terrama2::core::DataSeries* dataSeries = new terrama2::core::DataSeries();
+    terrama2::core::DataSeriesPtr dataSeriesPtr(dataSeries);
+    auto& semanticsManager = terrama2::core::SemanticsManager::getInstance();
+    dataSeries->semantics = semanticsManager.getSemantics("DCP-inpe");
+
+    terrama2::core::DataSetDcp* dataSet = new terrama2::core::DataSetDcp();
+    dataSet->active = true;
+    dataSet->format.emplace("mask", "30885.txt");
+    dataSet->format.emplace("timezone", "+00");
+
+    dataSeries->datasetList.emplace_back(dataSet);
+
+    //empty filter
+    terrama2::core::Filter filter;
+    std::string uri = "";
+    std::string mask = dataSet->format.at("mask");
+
+    //accessing data
+    terrama2::core::DataAccessorDcpInpe accessor(dataProviderPtr, dataSeriesPtr);
+
+    std::unique_ptr<te::da::MockDataSource> mock_(new te::da::MockDataSource());
+
+    ON_CALL(*mock_.get(), isOpened()).WillByDefault(Return(true));
+
+    try
+    {
+      terrama2::core::DcpSeriesPtr dcpSeries = accessor.getDcpSeries(filter);
+    }
+    catch(const terrama2::Exception&)
+    {
+      QFAIL("Exception expected!");
+    }
+  }
+  catch(terrama2::Exception& e)
+  {
+    QFAIL(boost::get_error_info< terrama2::ErrorDescription >(e)->toStdString().c_str());
+  }
+
+  catch(...)
+  {
+    QFAIL("Unexpected exception!");
+  }
+
+  return;
+
+}
+
+void TsDataAccessorDcpInpe::TestDataSourceInvalid()
+{
+  try
+  {
+    //DataProvider information
+    terrama2::core::DataProvider* dataProvider = new terrama2::core::DataProvider();
+    terrama2::core::DataProviderPtr dataProviderPtr(dataProvider);
+    dataProvider->uri = "file://";
+    dataProvider->uri+=TERRAMA2_DATA_DIR;
+    dataProvider->uri+="/PCD_serrmar_INPE";
+
+    dataProvider->intent = terrama2::core::DataProviderIntent::COLLECTOR_INTENT;
+    dataProvider->dataProviderType = "FILE";
+    dataProvider->active = true;
+
+    //DataSeries information
+    terrama2::core::DataSeries* dataSeries = new terrama2::core::DataSeries();
+    terrama2::core::DataSeriesPtr dataSeriesPtr(dataSeries);
+    auto& semanticsManager = terrama2::core::SemanticsManager::getInstance();
+    dataSeries->semantics = semanticsManager.getSemantics("DCP-inpe");
+
+    terrama2::core::DataSetDcp* dataSet = new terrama2::core::DataSetDcp();
+    dataSet->active = true;
+    dataSet->format.emplace("mask", "30885.txt");
+    dataSet->format.emplace("timezone", "+00");
+
+    dataSeries->datasetList.emplace_back(dataSet);
+
+    //empty filter
+    terrama2::core::Filter filter;
+    std::string uri = "";
+    std::string mask = dataSet->format.at("mask");
+
+    //accessing data
+    terrama2::core::DataAccessorDcpInpe accessor(dataProviderPtr, dataSeriesPtr);
+
+    std::unique_ptr<te::da::MockDataSource> mock_(new te::da::MockDataSource());
+
+    ON_CALL(*mock_.get(), isOpened()).WillByDefault(Return(false));
 
     try
     {

--- a/src/unittest/core/TsDataAccessorDcpInpe.hpp
+++ b/src/unittest/core/TsDataAccessorDcpInpe.hpp
@@ -50,6 +50,8 @@ class TsDataAccessorDcpInpe: public QObject
     void TestFailDataSeriesSemanticsInvalid();
     void TestOKDataRetrieverValid();
     void TestFailDataRetrieverInvalid();
+    void TestDataSourceValid();
+    void TestDataSourceInvalid();
     void TestOK();
 };
 


### PR DESCRIPTION
Ticket #531 - Review methods const in Mock:
- const methods should use macro MOCK_CONST_METHOD review the use of macros.