### PR TITLE
Small fix: adding monitored_object_pk in analysis output data series

### DIFF
--- a/webapp/controllers/api/Uri.js
+++ b/webapp/controllers/api/Uri.js
@@ -11,7 +11,7 @@ module.exports = function(app) {
         var factoryResult = RequestFactory.build(obj);
 
         factoryResult.request().then(function() {
-          response.json({status:200});
+          return response.json({status:200});
         }).catch(function(err) {
           handleRequestError(response, err, 400);
         });

--- a/webapp/core/AbstractRequest.js
+++ b/webapp/core/AbstractRequest.js
@@ -18,13 +18,15 @@ var AbstractRequest = function(params) {
 
   if (params instanceof Object) {
     var splitHost = (params[this.syntax().HOST] || "").split("://");
-    if (splitHost.length > 1)
+    if (splitHost.length > 1) {
       params[this.syntax().HOST] = splitHost[1];
+    }
 
+    var pathNameEnum = this.syntax().PATHNAME;
+    params[pathNameEnum] = params[pathNameEnum] || "/";
     this.params = params;
     this.uri = UriBuilder.buildUri(params, this.syntax());
-  }
-  else if (typeof params === "string") {
+  } else if (typeof params === "string") {
     this.uri = params;
     this.params = UriBuilder.buildObject(params, this.syntax());
   }

--- a/webapp/core/FtpRequest.js
+++ b/webapp/core/FtpRequest.js
@@ -49,7 +49,7 @@ FtpRequest.prototype.request = function() {
           error = new Exceptions.ConnectionError("Error in connection");
       }
 
-      reject(error);
+      return reject(error);
     });
 
     client.raw.quit(function(err, data) {
@@ -57,13 +57,13 @@ FtpRequest.prototype.request = function() {
         return reject(err);
       }
 
-      resolve();
+      return resolve();
     });
   });
 };
 
 FtpRequest.fields = function() {
-  return Utils.makeCommonRequestFields("FTP", 21, null, [UriPattern.HOST, UriPattern.PORT, UriPattern.PATHNAME],
+  return Utils.makeCommonRequestFields("FTP", 21, null, [UriPattern.HOST, UriPattern.PORT],
          Utils.getCommonRequestFields().concat([{key: UriPattern.PATHNAME, type: Form.Field.TEXT, htmlClass: 'col-md-12 terrama2-schema-form'}]));
 };
 

--- a/webapp/core/Utils.js
+++ b/webapp/core/Utils.js
@@ -110,7 +110,6 @@ var Utils = module.exports = {
 
     return {
       name: scheme,
-
       properties: properties,
       required: required,
       display: displayOrder

--- a/webapp/public/javascripts/angular/analysis/registration.js
+++ b/webapp/public/javascripts/angular/analysis/registration.js
@@ -733,6 +733,7 @@ angular.module('terrama2.analysis.registration', [
           $scope.metadata[$scope.targetDataSeries.name]['identifier'] = $scope.identifier;
           // setting monitored object id in output data series format
           $scope.modelStorager.monitored_object_id = $scope.targetDataSeries.id;
+          $scope.modelStorager.monitored_object_pk = $scope.identifier;
           break;
       }
 


### PR DESCRIPTION
- [x] Adding monitored_object_pk in analysis output data series - [807](https://trac.dpi.inpe.br/terrama2/ticket/807)
- [x] Allow pathname null (default ```/```) in DataProvider protocol (FTP, HTTP) - [809](https://trac.dpi.inpe.br/terrama2/ticket/809)