### PR TITLE
Webapp: Adding HTTPS support

### DIFF
--- a/webapp/bin/www
+++ b/webapp/bin/www
@@ -3,12 +3,6 @@
 'use strict';
 
 /**
- * Module dependencies.
- */
-
-var Database = require('./../config/Database');
-
-/**
  * It defines which context nodejs should initialize. The context names are available in {@link config/config.terrama2}
  * @typeof {string}
  */
@@ -19,15 +13,27 @@ var nodeContext = process.argv[2];
  */
 var nodeContextPort = process.argv[3];
 
+/**
+ * It defines TerraMA² global configuration (Singleton). Make sure it initializes before everything
+ * 
+ * @type {Application}
+ */
+var Application = require("./../core/Application");
+
 // setting currentContext
-Database.setCurrentContext(nodeContext);
+Application.setCurrentContext(nodeContext);
+
+/**
+ * Module dependencies.
+ */
+var Database = require('./../config/Database');
 
 return Database.init(nodeContext).then(function (sequelize) {
   var app = require('../app');
-  var Application = require("./../core/Application");
+  var HTTPFactory = require("./../config/HTTPFactory");
   var io = require('../io');
   var debug = require('debug')('webapp:server');
-  var http = require('http');
+  var http = require('https');
   var load = require('express-load');
   var portNumber = '36000';
   var PluginLoader = require("../core/PluginLoader");
@@ -35,12 +41,12 @@ return Database.init(nodeContext).then(function (sequelize) {
   var PortScanner = require("./../core/PortScanner");
   var TcpService = require("./../core/facade/tcp-manager/TcpService");
 
-  var currentContext = Database.getContextConfig();
+  var settings = Application.getContextConfig();
 
   var debugMessage = "";
 
-  if (PortScanner.isValidPort(currentContext.port)) {
-    portNumber = currentContext.port;
+  if (PortScanner.isValidPort(settings.port)) {
+    portNumber = settings.port;
   } else {
     debugMessage = "No valid port found. The default port " + portNumber + " will be used";
   }
@@ -54,7 +60,7 @@ return Database.init(nodeContext).then(function (sequelize) {
   /**
    * Create HTTP server.
    */
-  var server = http.createServer(app);
+  var server = HTTPFactory.create(app, settings);
 
   return PluginLoader.initialize(__dirname + "/../plugins/").then(function() {
 

--- a/webapp/config/Database.js
+++ b/webapp/config/Database.js
@@ -1,4 +1,5 @@
-var Promise = require('bluebird');
+var Application = require("./../core/Application");
+var Promise = require('./../core/Promise');
 var pg = require('pg');
 var util = require('util');
 var fs = require('fs');
@@ -20,12 +21,6 @@ var Database = function(pathToConfig) {
   if (pathToConfig === undefined || !pathToConfig) {
     pathToConfig = path.join(__dirname, 'config.terrama2');
   }
-
-  /**
-   * It stores a config.terrama2 settings
-   * @type {Object} config
-   */
-  this.config = JSON.parse(fs.readFileSync(pathToConfig, 'utf-8'));
 
   /**
    * It defines a current context key
@@ -54,35 +49,6 @@ Database.prototype.getORM = function() {
 };
 
 /**
- * It retrieves a current context config
- * 
- * @returns {Object}
- */
-Database.prototype.getContextConfig = function() {
-  return this.config[this.currentContext];
-};
-
-/**
- * It sets current terrama2 context
- *
- * @throws {Error} When a contexts is not in config.terrama2 
- * @param {string} context
- * @returns {void}
- */
-Database.prototype.setCurrentContext = function(context) {
-  if (!context) {
-    return;
-  }
-  // checking if there is a context in configuration file
-  if (this.config && !this.config.hasOwnProperty(context)) {
-    var msg = util.format("\"%s\" not found in configuration file. Please check \"webapp/config/config.terrama2\"", context);
-    throw new Error(msg);
-  }
-
-  this.currentContext = context;
-};
-
-/**
  * It initializes database, creating database, schema and postgis support. Once prepared, it retrieves a ORM instance
  * 
  * @returns {Promise<Connection>}
@@ -95,7 +61,7 @@ Database.prototype.init = function() {
       return resolve(sequelize);
     }
 
-    var currentContext = self.getContextConfig();
+    var currentContext = Application.getContextConfig();
 
     /**
      * Current database configuration context

--- a/webapp/config/HTTPFactory.js
+++ b/webapp/config/HTTPFactory.js
@@ -1,0 +1,50 @@
+// NodeJS dependencies
+var fs = require("fs");
+
+/**
+ * It defines a HTTP factory for handling HTTP and HTTPs protocols.
+ */
+var HttpFactory = module.exports = {};
+
+/**
+ * It configures a SSL options if there is in settings.
+ * 
+ * @example
+ * // config.terrama2
+ * {default: {..., ssl: true}} - It will use default SSL path (webapp/config/key|cert)
+ * 
+ * {default: {..., ssl: {key: pathToKey, cert: pathToCert}}} - It will use custom key path (Remember it based in webapp/config path if not starts with slash) 
+ */
+function setup (ssl) {
+  if (ssl) {
+    return {
+      key  : fs.readFileSync(ssl.key || "key.pem"),
+      cert : fs.readFileSync(ssl.certificate || "cert.pem")
+    };
+  }
+}
+
+/**
+ * It builds a HTTP or HTTPS server and start
+ * 
+ * @param {Express} app - NodeJS express
+ * @param {any?} options - Server options
+ * @returns {Server}
+ */
+function startServer(app, options) {
+  if (options) {
+    return require('https').createServer(options, app);
+  }
+  return require('http').createServer(app);
+}
+
+/**
+ * It creates a HTTP or HTTPS server based in TerraMA² Settings (Look in Application.js)
+ * @param {Express} app - NodeJS express
+ * @param {Object} settings - TerraMA² Settings
+ * @returns {Server}
+ */
+HttpFactory.create = function(app, settings) {
+  var options = setup(settings.ssl);
+  return startServer(app, options);
+};

--- a/webapp/config/Sequelize.js
+++ b/webapp/config/Sequelize.js
@@ -1,5 +1,15 @@
 var Sequelize = require('sequelize');
 
+/**
+ * It defines a Sequelize ORM initialization. It depends TerraMA² database config
+ * 
+ * @param {Object} config - A database config
+ * @param {string} config.database - Database name
+ * @param {string} config.username - Database user
+ * @param {string} config.password - User password
+ * @param {Object?} config.define - Extra database configuration (Sequelize)
+ * @returns {Sequelize.Instance}
+ */
 module.exports = function(config) {
   return new Sequelize(config.database, config.username, config.password, config);
 };

--- a/webapp/core/Application.js
+++ b/webapp/core/Application.js
@@ -1,8 +1,34 @@
 var fs = require("fs");
 var path = require("path");
 
-var _data = {};
+/**
+ * It defines a cache object (private) with TerraMA² settings
+ * @type {Object}
+ */
+var _data = {
+  /**
+   * TerraMA² webapp metadata
+   * @type {Object}
+   */
+  "metadata": {},
+  /**
+   * It defines a global terrama2 settings (config.terrama2). It contains database config, etc.
+   * @type {Object}
+   */
+  "settings": {}
+};
 
+/**
+ * It defines which context TerraMA² should run. (default "default")
+ * @type {string}
+ */
+var _context = "default";
+
+/**
+ * It defines a TerraMA² Application metadata.
+ * 
+ * It loads WebApp metadata (package.json), Database configuration (config/config.terrama2)
+ */
 function Application() {
   this.load();
 }
@@ -13,18 +39,58 @@ function Application() {
  * @throws TypeError When read content is not a valid json
  */
 Application.prototype.load = function() {
+  // reading TerraMA² webapp metadata
   var buffer = JSON.parse(fs.readFileSync(path.join(__dirname, "../package.json"), "utf-8"));
 
-  _data.name = buffer.name;
-  _data.version = buffer.version;
-  _data.fullName = buffer.name + " " + buffer.version;
+  _data.metadata.name = buffer.name;
+  _data.metadata.version = buffer.version;
+  _data.metadata.fullName = buffer.name + " " + buffer.version;
+
+  // reading TerraMA² config.json
+  buffer = JSON.parse(fs.readFileSync(path.join(__dirname, "../config/config.terrama2"), "utf-8"));
+
+  _data.settings = buffer;
 };
 
 /**
- * It retrieves a copy of TerraMA² running aplication metadata. It contains name, version
+ * It sets current terrama2 context
+ *
+ * @throws {Error} When a contexts is not in config.terrama2 
+ * @param {string} context
+ * @returns {void}
+ */
+Application.prototype.setCurrentContext = function(context) {
+  if (!context) {
+    return;
+  }
+  // checking if there is a context in configuration file
+  if (_data.settings && !_data.settings.hasOwnProperty(context)) {
+    var msg = util.format("\"%s\" not found in configuration file. Please check \"webapp/config/config.terrama2\"", context);
+    throw new Error(msg);
+  }
+
+  _context = context;
+};
+
+/**
+ * It retrieves a current context config
+ * 
  * @returns {Object}
  */
-Application.prototype.get = function() {
+Application.prototype.getContextConfig = function() {
+  return _data.settings[_context];
+};
+
+/**
+ * It retrieves a copy of TerraMA² running aplication settings. It contains name, version
+ * 
+ * @param {string} settingName - Defines which values want to return. It retrieves a copy of real object in order to keep safe. Used it as much as possible for performance reasons
+ * @returns {Object}
+ */
+Application.prototype.get = function(settingName) {
+  if (settingName) {
+    return Object.assign({}, _data[settingName]);
+  }
   return Object.assign({}, _data);
 };
 

--- a/webapp/core/DataManager.js
+++ b/webapp/core/DataManager.js
@@ -22,6 +22,7 @@
  * TerraMA2 Team at <terrama2-team@dpi.inpe.br>.
 */
 
+var Application = require("./Application");
 var modelsFn = require("../models");
 var exceptions = require('./Exceptions');
 var Promise = require('bluebird');
@@ -98,7 +99,7 @@ var DataManager = module.exports = {
   init: function(callback) {
     var self = this;
 
-      var dbConfig = Database.getContextConfig().db;
+      var dbConfig = Application.getContextConfig().db;
 
       models = modelsFn();
       models.load(orm);

--- a/webapp/core/facade/tcp-manager/TcpService.js
+++ b/webapp/core/facade/tcp-manager/TcpService.js
@@ -34,6 +34,12 @@ var RegisteredView = require("./../../../core/data-model/RegisteredView");
 var Application = require("./../../Application");
 
 /**
+ * It defines TerraMA² webapp metadata (package.json)
+ * @type {Object}
+ */
+var webapp = Application.get("metadata");
+
+/**
  * It handles TCP service manipulation. Use  it to be pipe between front-end and back-end application
  * 
  * @class TcpService
@@ -588,7 +594,7 @@ function onStatusReceived(service, response) {
  * @param {string} response - Response version
  */
 function onServiceVersionReceived(service, response) {
-  var version = Application.get().version;
+  var version = webapp.version;
   tcpService.emit("serviceVersion", {
     service: service.id,
     response: response.replace("TerraMA2", ""),

--- a/webapp/public/javascripts/angular/services/service.js
+++ b/webapp/public/javascripts/angular/services/service.js
@@ -89,6 +89,7 @@
           service.loading = false;
           service.online = false;
           service.requestingForClose = false;
+          service.stoping = false;
         });
 
         $scope.socket.on('errorResponse', function(response) {
@@ -177,10 +178,6 @@
                   }
                 }
               });
-
-              $scope.socket.once('statusResponse', function(response) {
-                $scope.extra.service.starting = false;
-              });
             },
 
             stopAll: function() {
@@ -193,9 +190,8 @@
                 }
               });
 
-              $scope.socket.once('closeResponse', function(response) {
-                $scope.extra.service.stoping = false;
-              });
+              $scope.extra.service.stoping = false;
+              $scope.extra.service.starting = false;
             },
 
             hasServiceOffline: function() {

--- a/webapp/public/javascripts/angular/table/templates/table.html
+++ b/webapp/public/javascripts/angular/table/templates/table.html
@@ -105,7 +105,6 @@
           </td>
           <td ng-repeat="field in identityFields ">
             <a ng-href="{{ makeLink(element) }}" ng-if="link">{{ processField(field, element) }}</a>
-            <!--{{ element[field] }}-->
           </td>
 
           <td ng-if="extra.project" class="pull-cell-left">


### PR DESCRIPTION
- [x] Adding HTTPS support - [515](https://trac.dpi.inpe.br/terrama2/ticket/515). In order to use it, add ```ssl: true``` in ```config/terrama2.json``` in respective context (default/tests,etc). Once configured, make sure you have .key and .cert file in webapp path. You can specify in config.terrama2 the path to .key and .cert files, for example:
```json
{
  "default": {
    "ssl": {
      "key": "/opt/terrama2/ssl/terrama2-key.pem",
      "cert": "/opt/terrama2/ssl/terrama2-cert.pem"
    },
    "port": 36000,
    "db": {...}
  }
}
```
**Note** ssl is ```false``` by default.
- [x] Fixing ```Start All/Stop All``` services display.