### PR TITLE
fix DataSeries DCP postgis fields

### DIFF
--- a/share/terrama2/semantics.json
+++ b/share/terrama2/semantics.json
@@ -401,14 +401,38 @@
           "table_name": {
             "type": "string",
             "title": "Table Name"
+          },
+          "latitude": {
+            "type": "number",
+            "title": "Latitude"
+          },
+          "longitude": {
+            "type": "number",
+            "title": "Longitude"
+          },
+          "projection": {
+            "type": "number",
+            "title": "SRID"
           }
         },
-        "required": ["table_name"]
+        "required": ["table_name", "latitude", "longitude", "projection"]
       },
       "form": [
         {
           "key": "table_name",
           "htmlClass": "col-md-5 terrama2-schema-form"
+        },
+        {
+          "key": "latitude",
+          "htmlClass": "col-md-2"
+        },
+        {
+          "key": "longitude",
+          "htmlClass": "col-md-2"
+        },
+        {
+          "key": "projection",
+          "htmlClass": "col-md-2"
         }
       ]
     }

--- a/src/terrama2/impl/DataAccessorFile.cpp
+++ b/src/terrama2/impl/DataAccessorFile.cpp
@@ -260,7 +260,7 @@ bool terrama2::core::DataAccessorFile::isValidRaster(std::shared_ptr<te::mem::Da
 
   std::shared_ptr< te::rst::Raster > raster(dataSet->getRaster(rasterColumn));
 
-  std::unique_ptr<const te::gm::Envelope> envelope(filter.region->getMBR());
+  auto envelope = filter.region->getMBR();
   if(!raster->getExtent(filter.region->getSRID())->intersects(*envelope))
     return false;
 

--- a/src/terrama2/impl/DataAccessorFile.cpp
+++ b/src/terrama2/impl/DataAccessorFile.cpp
@@ -555,14 +555,6 @@ terrama2::core::DataSetSeries terrama2::core::DataAccessorFile::getSeries(const 
       throw terrama2::core::DataAccessorException() << ErrorDescription(errMsg);
     }
 
-    auto raster = teDataSet->getRaster(0);
-    if(raster.get() == nullptr)
-    {
-      QString errMsg = QObject::tr("Invalid raster for dataset: %1").arg(dataSetName.c_str());
-      TERRAMA2_LOG_WARNING() << errMsg;
-      throw terrama2::core::DataAccessorException() << ErrorDescription(errMsg);
-    }
-
     addToCompleteDataSet(completeDataset, teDataSet, thisFileTimestamp, fileInfo.absoluteFilePath().toStdString());
 
     //update lastest file timestamp

--- a/src/terrama2/impl/DataAccessorGrADS.cpp
+++ b/src/terrama2/impl/DataAccessorGrADS.cpp
@@ -990,6 +990,9 @@ void terrama2::core::DataAccessorGrADS::writeVRTFile(terrama2::core::GrADSDataDe
     // In case 'yrev' option is given, we need to flip the image
     bool isYReverse = std::find(descriptor.vecOptions_.begin(), descriptor.vecOptions_.end(), "YREV") != descriptor.vecOptions_.end();
 
+    //FIXME: don't work if the image area stats before the 180 degree line and ends after.
+    //ticket: https://trac.dpi.inpe.br/terrama2/ticket/935
+
     //change longitude from 0/360 to -180/180
     if(descriptor.xDef_->values_[0] > 180)
       descriptor.xDef_->values_[0] = 180. - descriptor.xDef_->values_[0];

--- a/src/terrama2/impl/DataAccessorGrADS.cpp
+++ b/src/terrama2/impl/DataAccessorGrADS.cpp
@@ -1002,7 +1002,7 @@ void terrama2::core::DataAccessorGrADS::writeVRTFile(terrama2::core::GrADSDataDe
 
     //change longitude from 0/360 to -180/180
     if(descriptor.xDef_->values_[0] > 180)
-      descriptor.xDef_->values_[0] = 180. - descriptor.xDef_->values_[0];
+      descriptor.xDef_->values_[0] = descriptor.xDef_->values_[0] - 360;
 
     if((descriptor.xDef_->values_[1] == 0.0) || (descriptor.yDef_->values_[1] == 0.0))
     {

--- a/src/terrama2/impl/DataAccessorGrADS.cpp
+++ b/src/terrama2/impl/DataAccessorGrADS.cpp
@@ -487,6 +487,8 @@ terrama2::core::DataSetSeries terrama2::core::DataAccessorGrADS::getSeries(const
 
   filterDataSetByLastValue(completeDataset, filter, dataTimeStamp);
 
+  cropRaster(completeDataset, filter);
+
   //if both dates are valid
   if((lastFileTimestamp.get() && !lastFileTimestamp->getTimeInstantTZ().is_not_a_date_time())
       && (dataTimeStamp.get() && !dataTimeStamp->getTimeInstantTZ().is_not_a_date_time()))
@@ -989,6 +991,11 @@ void terrama2::core::DataAccessorGrADS::writeVRTFile(terrama2::core::GrADSDataDe
 
     // In case 'yrev' option is given, we need to flip the image
     bool isYReverse = std::find(descriptor.vecOptions_.begin(), descriptor.vecOptions_.end(), "YREV") != descriptor.vecOptions_.end();
+
+    //change longitude from 0/360 to -180/180
+    if(descriptor.xDef_->values_[0] > 180)
+      descriptor.xDef_->values_[0] = 180. - descriptor.xDef_->values_[0];
+
     if(isYReverse)
     {
       /// Uses a transformation to flip the image

--- a/src/terrama2/impl/DataAccessorGrADS.hpp
+++ b/src/terrama2/impl/DataAccessorGrADS.hpp
@@ -227,6 +227,8 @@ namespace terrama2
                           const std::string& vrtFilename, DataSetPtr dataset) const;
 
         std::unique_ptr<te::rst::Raster> adaptRaster(const std::unique_ptr<te::rst::Raster>& raster) const;
+
+        mutable bool yReverse_ = false; //! Flag for reverse y-axis.
     };
 
 


### PR DESCRIPTION
- DataAccessorFile and DataAccessorGrADS review
- half-fix Longitude from 0/360 to -180/180 in GrADS files
 - details in [#935](https://trac.dpi.inpe.br/terrama2/ticket/935)
- fix GrADS y-axis orientation