### PR TITLE
Using binary mask to overwrite CTL configuration for remote data 

### DIFF
--- a/src/examples/core/ProcessLogger.cpp
+++ b/src/examples/core/ProcessLogger.cpp
@@ -80,16 +80,16 @@ int main(int argc, char* argv[])
     log.logValue("tag2", "value4", registerID);
 
     // Log errors
-    log.error("Unit Test Error", registerID);
-    log.error("Unit Test second Error", registerID);
+    log.log(Logger::ERROR_MESSAGE, "Unit Test Error", registerID);
+    log.log(Logger::ERROR_MESSAGE, "Unit Test second Error", registerID);
 
     // Log informations
-    log.info("Unit Test Info", registerID);
-    log.info("Unit Test seconde Info", registerID);
+    log.log(Logger::INFO_MESSAGE, "Unit Test Info", registerID);
+    log.log(Logger::INFO_MESSAGE, "Unit Test seconde Info", registerID);
 
     // Log the end of process with the timestamp of processed data
     std::shared_ptr< te::dt::TimeInstantTZ > data_dateTime = terrama2::core::TimeUtils::nowUTC();
-    log.done(data_dateTime, registerID);
+    log.result(Logger::ERROR, data_dateTime, registerID);
 
     // Get the process ID consulting by register ID
     ProcessId process_id = log.processID(registerID);

--- a/src/examples/core/ProcessLogger.cpp
+++ b/src/examples/core/ProcessLogger.cpp
@@ -89,7 +89,7 @@ int main(int argc, char* argv[])
 
     // Log the end of process with the timestamp of processed data
     std::shared_ptr< te::dt::TimeInstantTZ > data_dateTime = terrama2::core::TimeUtils::nowUTC();
-    log.result(Logger::ERROR, data_dateTime, registerID);
+    log.result(Logger::DONE, data_dateTime, registerID);
 
     // Get the process ID consulting by register ID
     ProcessId process_id = log.processID(registerID);

--- a/src/terrama2/core/utility/ProcessLogger.cpp
+++ b/src/terrama2/core/utility/ProcessLogger.cpp
@@ -191,64 +191,36 @@ void terrama2::core::ProcessLogger::addValue(const std::string& tag, const std::
 }
 
 
-void terrama2::core::ProcessLogger::error(const std::string& description, RegisterId registerId) const
+void
+terrama2::core::ProcessLogger::log(MessageType messageType, const std::string &description, RegisterId registerId) const
 {
   if(tableName_.empty() || messagesTableName_.empty())
   {
-    QString errMsg = QObject::tr("Can not find log tables names. Are they setted?");
+    QString errMsg = QObject::tr("Can not find log tables names.");
     TERRAMA2_LOG_ERROR() << errMsg;
     throw terrama2::core::LogException() << ErrorDescription(errMsg);
   }
 
   std::shared_ptr< te::dt::TimeInstantTZ> now(TimeUtils::nowUTC());
-
-  boost::format query("UPDATE "+ tableName_ + " SET status=%1%, last_process_timestamp='%2%' WHERE id =" + QString::number(registerId).toStdString());
-
-  query.bind_arg(1, static_cast<int>(Status::ERROR));
-  query.bind_arg(2, now->toString());
 
   std::string escapedDescription(description);
   // TODO: Remove it when terralib escape work properly
   std::replace(escapedDescription.begin(), escapedDescription.end(), '\'', ' ');
 
   boost::format queryMessages("INSERT INTO " + messagesTableName_ + " (log_id, type, description, timestamp) VALUES(" + QString::number(registerId).toStdString() + ", %1%, '%2%', '%3%')");
-  queryMessages.bind_arg(1, static_cast<int>(MessageType::ERROR_MESSAGE));
+  queryMessages.bind_arg(1, static_cast<int>(messageType));
   queryMessages.bind_arg(2, escapedDescription);
   queryMessages.bind_arg(3, now->toString());
 
   std::shared_ptr< te::da::DataSourceTransactor > transactor = dataSource_->getTransactor();
-
-  transactor->execute(query.str());
-  transactor->execute(transactor->escape(queryMessages.str()));
-
-  transactor->commit();
-}
-
-void terrama2::core::ProcessLogger::info(const std::string& description, RegisterId registerId) const
-{
-  if(tableName_.empty() || messagesTableName_.empty())
-  {
-    QString errMsg = QObject::tr("Can not find log tables names. Are they setted?");
-    TERRAMA2_LOG_ERROR() << errMsg;
-    throw terrama2::core::LogException() << ErrorDescription(errMsg);
-  }
-
-  std::shared_ptr< te::dt::TimeInstantTZ> now(TimeUtils::nowUTC());
-
-  boost::format queryMessages("INSERT INTO " + messagesTableName_ + " (log_id, type, description, timestamp) VALUES(" + QString::number(registerId).toStdString() + ", %1%, '%2%', '%3%')");
-  queryMessages.bind_arg(1, static_cast<int>(MessageType::INFO_MESSAGE));
-  queryMessages.bind_arg(2, description);
-  queryMessages.bind_arg(3, now->toString());
-
-  std::shared_ptr< te::da::DataSourceTransactor > transactor = dataSource_->getTransactor();
-
   transactor->execute(transactor->escape(queryMessages.str()));
 
   transactor->commit();
 }
 
 
-void terrama2::core::ProcessLogger::done(const std::shared_ptr<te::dt::TimeInstantTZ>& dataTimestamp, RegisterId registerId) const
+void terrama2::core::ProcessLogger::result(Status status, const std::shared_ptr<te::dt::TimeInstantTZ> &dataTimestamp,
+                                           RegisterId registerId) const
 {
   if(tableName_.empty())
   {
@@ -273,7 +245,7 @@ void terrama2::core::ProcessLogger::done(const std::shared_ptr<te::dt::TimeInsta
   }
 
 
-  query.bind_arg(1, static_cast<int>(Status::DONE));
+  query.bind_arg(1, static_cast<int>(status));
   query.bind_arg(2, timestamp);
   query.bind_arg(3, TimeUtils::nowUTC()->toString());
 

--- a/src/terrama2/core/utility/ProcessLogger.hpp
+++ b/src/terrama2/core/utility/ProcessLogger.hpp
@@ -113,22 +113,18 @@ namespace terrama2
         virtual RegisterId start(ProcessId processId) const;
 
         /*!
-         * \brief Log an error of process
+         * \brief Adds a log message to the process.
          * \param description Error description
          */
-        virtual void error(const std::string& description, const RegisterId registerId) const;
+        virtual void log(MessageType messageType, const std::string &description, RegisterId registerId) const;
 
-        /*!
-         * \brief Log an information of process
-         * \param description Error description
-         */
-        virtual void info(const std::string& description, const RegisterId registerId) const;
 
         /*!
          * \brief Log the end of process
          * \param dataTimestamp The las timestamp of data.
          */
-        virtual void done(const std::shared_ptr< te::dt::TimeInstantTZ >& dataTimestamp, const RegisterId registerId) const;
+        virtual void result(Status status, const std::shared_ptr<te::dt::TimeInstantTZ> &dataTimestamp,
+                            RegisterId registerId) const;
 
         /*!
          * \brief Returns the process last log timestamp

--- a/src/terrama2/impl/DataAccessorGrADS.cpp
+++ b/src/terrama2/impl/DataAccessorGrADS.cpp
@@ -129,6 +129,20 @@ std::string terrama2::core::DataAccessorGrADS::retrieveData(const DataRetrieverP
 
     datasetMask = grad2TerramaMask(datasetMask.c_str()).toStdString();
 
+    // In case the user specified a binary file mask, use it instead of the one in the CTL file.
+    try
+    {
+      std::string binaryFileMask = getBinaryFileMask(dataset);
+      if(!binaryFileMask.empty())
+      {
+        datasetMask = binaryFileMask;
+      }
+    }
+    catch(...)
+    {
+      // In case no binary file mask specified, use dataset mask in the CTL file.
+    }
+
     dataRetriever->retrieveData(datasetMask, filter, remover, uri, folderPath);
   }
 

--- a/src/terrama2/services/alert/core/RunAlert.cpp
+++ b/src/terrama2/services/alert/core/RunAlert.cpp
@@ -60,10 +60,10 @@ void terrama2::services::alert::core::runAlert(std::pair<AlertId, std::shared_pt
     return;
   }
 
+  RegisterId logId = 0;
   try
   {
     auto alertId = alertInfo.first;
-    RegisterId logId = 0;
 
     logId = logger->start(alertId);
 
@@ -101,7 +101,8 @@ void terrama2::services::alert::core::runAlert(std::pair<AlertId, std::shared_pt
     auto dataMap = dataAccessor->getSeries(filter, remover);
     if(dataMap.empty())
     {
-      logger->done(nullptr, logId);
+      logger->result(AlertLogger::ERROR, nullptr, logId);
+      logger->log(AlertLogger::ERROR_MESSAGE, QObject::tr("No data to available.").toStdString(), logId);
       TERRAMA2_LOG_WARNING() << QObject::tr("No data to available.");
       return;
     }
@@ -179,25 +180,34 @@ void terrama2::services::alert::core::runAlert(std::pair<AlertId, std::shared_pt
       report->process(alertPtr, dataset, alertInfo.second, alertDataSet);
     }
 
-    logger->done(alertInfo.second, logId);
+    logger->result(AlertLogger::DONE, alertInfo.second, logId);
   }
   catch(const terrama2::Exception& e)
   {
+    logger->result(AlertLogger::ERROR, nullptr, logId);
+    logger->log(AlertLogger::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString(), logId);
     TERRAMA2_LOG_DEBUG() << boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString();
     throw;//re-throw
   }
   catch(boost::exception& e)
   {
+    logger->result(AlertLogger::ERROR, nullptr, logId);
+    logger->log(AlertLogger::ERROR_MESSAGE, boost::diagnostic_information(e), logId);
     TERRAMA2_LOG_ERROR() << boost::diagnostic_information(e);
   }
   catch(std::exception& e)
   {
     QString errMsg(e.what());
+    logger->result(AlertLogger::ERROR, nullptr, logId);
+    logger->log(AlertLogger::ERROR_MESSAGE, e.what(), logId);
     TERRAMA2_LOG_ERROR() << errMsg;
   }
   catch(...)
   {
-    TERRAMA2_LOG_ERROR() << QObject::tr("Unknown exception");
+    QString errMsg = QObject::tr("Unknown exception");
+    logger->result(AlertLogger::ERROR, nullptr, logId);
+    logger->log(AlertLogger::ERROR_MESSAGE, errMsg.toStdString(), logId);
+    TERRAMA2_LOG_ERROR() << errMsg;
   }
 }
 

--- a/src/terrama2/services/alert/core/RunAlert.cpp
+++ b/src/terrama2/services/alert/core/RunAlert.cpp
@@ -101,8 +101,8 @@ void terrama2::services::alert::core::runAlert(std::pair<AlertId, std::shared_pt
     auto dataMap = dataAccessor->getSeries(filter, remover);
     if(dataMap.empty())
     {
-      logger->result(AlertLogger::ERROR, nullptr, logId);
-      logger->log(AlertLogger::ERROR_MESSAGE, QObject::tr("No data to available.").toStdString(), logId);
+      logger->result(AlertLogger::DONE, nullptr, logId);
+      logger->log(AlertLogger::WARNING_MESSAGE, QObject::tr("No data to available.").toStdString(), logId);
       TERRAMA2_LOG_WARNING() << QObject::tr("No data to available.");
       return;
     }

--- a/src/terrama2/services/analysis/core/AnalysisExecutor.cpp
+++ b/src/terrama2/services/analysis/core/AnalysisExecutor.cpp
@@ -314,18 +314,18 @@ void terrama2::services::analysis::core::AnalysisExecutor::runMonitoredObjectAna
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f) { f.get(); });
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f) { f.get(); });
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f) { f.get(); });
   }
 
@@ -436,7 +436,7 @@ void terrama2::services::analysis::core::AnalysisExecutor::storeMonitoredObjectA
       if(!context->exists(datasetMO->id))
       {
         QString errMsg(QObject::tr("Could not recover monitored object dataset."));
-        context->addError(errMsg.toStdString());
+        context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
         return;
       }
 
@@ -445,14 +445,14 @@ void terrama2::services::analysis::core::AnalysisExecutor::storeMonitoredObjectA
       if(moDsContext->identifier.empty())
       {
         QString errMsg(QObject::tr("Monitored object identifier is empty."));
-        context->addError(errMsg.toStdString());
+        context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
         return;
       }
 
       if(!moDsContext->series.teDataSetType)
       {
         QString errMsg(QObject::tr("Invalid dataset type."));
-        context->addError(errMsg.toStdString());
+        context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
         return;
       }
 
@@ -468,14 +468,14 @@ void terrama2::services::analysis::core::AnalysisExecutor::storeMonitoredObjectA
   if(!found)
   {
     QString errMsg(QObject::tr("Could not find a monitored object dataseries."));
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return;
   }
 
   if(!identifierProperty)
   {
     QString errMsg(QObject::tr("Invalid monitored object attribute identifier."));
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return;
   }
 
@@ -567,7 +567,7 @@ void terrama2::services::analysis::core::AnalysisExecutor::runGridAnalysis(DataM
   if(!analysis->outputGridPtr)
   {
     QString errMsg = QObject::tr("Invalid output grid configuration.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return;
   }
 
@@ -654,29 +654,29 @@ void terrama2::services::analysis::core::AnalysisExecutor::runGridAnalysis(DataM
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f) { f.get(); });
   }
   catch(const boost::python::error_already_set&)
   {
     std::string errMsg = terrama2::services::analysis::core::python::extractException();
-    context->addError(errMsg);
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg);
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f) { f.get(); });
   }
   catch(const boost::exception& e)
   {
-    context->addError(boost::diagnostic_information(e));
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::diagnostic_information(e));
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f) { f.get(); });
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f) { f.get(); });
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f){ f.get(); });
   }
 
@@ -782,18 +782,18 @@ void terrama2::services::analysis::core::AnalysisExecutor::storeGridAnalysisResu
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return;
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     return;
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred trying to store the results.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return;
   }
 }

--- a/src/terrama2/services/analysis/core/AnalysisExecutor.cpp
+++ b/src/terrama2/services/analysis/core/AnalysisExecutor.cpp
@@ -170,7 +170,7 @@ void terrama2::services::analysis::core::AnalysisExecutor::runAnalysis(DataManag
         logger->log(AnalysisLogger::ERROR_MESSAGE, error, logId);
       }
 
-      QString errMsg = QObject::tr("Analysis %1 (%2) finished with the following log(s):\n%3").arg(analysis->id).arg(startTime->toString().c_str()).arg(QString::fromStdString(errorStr));
+      QString errMsg = QObject::tr("Analysis %1 (%2) finished with the following error(s):\n%3").arg(analysis->id).arg(startTime->toString().c_str()).arg(QString::fromStdString(errorStr));
       TERRAMA2_LOG_INFO() << errMsg;
 
       logger->result(AnalysisLogger::ERROR, startTime, logId);

--- a/src/terrama2/services/analysis/core/BaseContext.cpp
+++ b/src/terrama2/services/analysis/core/BaseContext.cpp
@@ -54,7 +54,13 @@ terrama2::services::analysis::core::BaseContext::~BaseContext()
 void terrama2::services::analysis::core::BaseContext::addError(const std::string& errorMessage)
 {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  errorsSet_.insert(errorMessage);
+  logMessages_[ERROR_MESSAGE].insert(errorMessage);
+}
+
+void terrama2::services::analysis::core::BaseContext::addWarning(const std::string& message)
+{
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  logMessages_[WARNING_MESSAGE].insert(message);
 }
 
 terrama2::core::DataSeriesPtr terrama2::services::analysis::core::BaseContext::findDataSeries(const std::string& dataSeriesName)
@@ -239,4 +245,23 @@ terrama2::services::analysis::core::BaseContext::getSeriesMap(DataSeriesId dataS
     analysisSeriesMap_.emplace(key, series);
     return series;
   }
+}
+
+const std::set<std::string> terrama2::services::analysis::core::BaseContext::getMessages(
+    const BaseContext::MessageType messageType) const
+{
+  auto it = logMessages_.find(messageType);
+  if(it != logMessages_.end())
+    return it->second;
+
+  return std::set<std::string>();
+}
+
+bool terrama2::services::analysis::core::BaseContext::hasError() const
+{
+  auto it = logMessages_.find(ERROR_MESSAGE);
+  if(it == logMessages_.end())
+    return false;
+
+  return !it->second.empty();
 }

--- a/src/terrama2/services/analysis/core/BaseContext.cpp
+++ b/src/terrama2/services/analysis/core/BaseContext.cpp
@@ -51,17 +51,12 @@ terrama2::services::analysis::core::BaseContext::~BaseContext()
 {
 }
 
-void terrama2::services::analysis::core::BaseContext::addError(const std::string& errorMessage)
+void terrama2::services::analysis::core::BaseContext::addLogMessage(MessageType messageType, const std::string &message)
 {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  logMessages_[ERROR_MESSAGE].insert(errorMessage);
+  logMessages_[messageType].insert(message);
 }
 
-void terrama2::services::analysis::core::BaseContext::addWarning(const std::string& message)
-{
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
-  logMessages_[WARNING_MESSAGE].insert(message);
-}
 
 terrama2::core::DataSeriesPtr terrama2::services::analysis::core::BaseContext::findDataSeries(const std::string& dataSeriesName)
 {

--- a/src/terrama2/services/analysis/core/BaseContext.hpp
+++ b/src/terrama2/services/analysis/core/BaseContext.hpp
@@ -157,17 +157,10 @@ namespace terrama2
 
 
             /*!
-              \brief Adds an error message to list of errors that occurred in the analysis execution.
-              \param errorMessage The error message.
+              \brief Adds an log message to the list that occurred in the analysis execution.
+              \param message The log message.
             */
-            void addError(const std::string& errorMessage);
-
-
-            /*!
-              \brief Adds an warning message to the list of messages that occurred in the analysis execution.
-              \param errorMessage The warning message.
-            */
-            void addWarning(const std::string& message);
+            void addLogMessage(MessageType messageType, const std::string &message);
 
             terrama2::core::DataSeriesPtr findDataSeries(const std::string& dataSeriesName);
 

--- a/src/terrama2/services/analysis/core/BaseContext.hpp
+++ b/src/terrama2/services/analysis/core/BaseContext.hpp
@@ -106,19 +106,6 @@ namespace terrama2
           }
         };
 
-        /*!
-          \brief Comparator the context key.
-        */
-        struct LessKeyComparator
-        {
-          /*!
-            \brief Operator less then.
-          */
-          bool operator()(const ObjectKey& lhs, const ObjectKey& rhs) const
-          {
-            return lhs.hashCode() < rhs.hashCode();
-          }
-        };
 
         struct EqualKeyComparator
         {
@@ -131,6 +118,19 @@ namespace terrama2
         class BaseContext : public std::enable_shared_from_this<BaseContext>
         {
           public:
+
+            /*!
+              \enum messageType
+
+              \brief Possible status of logged messages.
+            */
+            enum MessageType
+            {
+              ERROR_MESSAGE = 1,
+              INFO_MESSAGE = 2,
+              WARNING_MESSAGE = 3
+            };
+
             BaseContext(terrama2::services::analysis::core::DataManagerPtr dataManager, terrama2::services::analysis::core::AnalysisPtr analysis, std::shared_ptr<te::dt::TimeInstantTZ> startTime);
 
             virtual ~BaseContext();
@@ -139,7 +139,10 @@ namespace terrama2
             BaseContext& operator=(const BaseContext& other) = default;
             BaseContext& operator=(BaseContext&& other) = default;
 
-            inline const std::set<std::string>& getErrors() const { return errorsSet_; }
+            const std::set<std::string> getMessages(const MessageType messageType) const;
+
+            bool hasError() const;
+
 
             /*!
               \brief Returns a weak pointer to the data manager.
@@ -158,6 +161,13 @@ namespace terrama2
               \param errorMessage The error message.
             */
             void addError(const std::string& errorMessage);
+
+
+            /*!
+              \brief Adds an warning message to the list of messages that occurred in the analysis execution.
+              \param errorMessage The warning message.
+            */
+            void addWarning(const std::string& message);
 
             terrama2::core::DataSeriesPtr findDataSeries(const std::string& dataSeriesName);
 
@@ -178,6 +188,8 @@ namespace terrama2
 
             std::unique_ptr<te::dt::TimeInstantTZ> getTimeFromString(const std::string& timeString) const;
 
+
+
           protected:
             /*!
               \brief Return the a multimap of DataSetGridPtr to Raster
@@ -190,16 +202,18 @@ namespace terrama2
 
             mutable std::recursive_mutex mutex_; //!< A mutex to synchronize all operations.
 
+
+
             std::weak_ptr<terrama2::services::analysis::core::DataManager> dataManager_;
             AnalysisPtr analysis_;
             std::shared_ptr<te::dt::TimeInstantTZ> startTime_;
-            std::set<std::string> errorsSet_;
+            std::map<BaseContext::MessageType, std::set<std::string> > logMessages_;
             std::shared_ptr<terrama2::core::FileRemover> remover_;
 
             std::unordered_map<std::string, terrama2::core::DataSeriesPtr > dataSeriesMap_;
             std::unordered_map<Srid, std::shared_ptr<te::srs::Converter> > converterMap_;
             std::unordered_map<ObjectKey, std::unordered_multimap<terrama2::core::DataSetGridPtr, std::shared_ptr<te::rst::Raster> >, ObjectKeyHash, EqualKeyComparator> analysisGridMap_;
-            std::unordered_map<ObjectKey, std::unordered_map<terrama2::core::DataSetPtr,terrama2::core::DataSetSeries >, ObjectKeyHash, EqualKeyComparator> analysisSeriesMap_;
+            std::unordered_map<ObjectKey, std::unordered_map<terrama2::core::DataSetPtr, terrama2::core::DataSetSeries >, ObjectKeyHash, EqualKeyComparator> analysisSeriesMap_;
             std::unordered_map<ObjectKey, std::vector<std::shared_ptr<te::rst::Raster> >, ObjectKeyHash, EqualKeyComparator > rasterMap_;
             std::unordered_map<std::shared_ptr<te::rst::Raster>, std::shared_ptr<terrama2::core::SynchronizedInterpolator> > interpolatorMap_;
         };

--- a/src/terrama2/services/analysis/core/ContextManager.cpp
+++ b/src/terrama2/services/analysis/core/ContextManager.cpp
@@ -162,14 +162,14 @@ std::set<std::string> terrama2::services::analysis::core::ContextManager::getErr
   auto itm = monitoredObjectContextMap_.find(analysisHashCode);
   if(itm != monitoredObjectContextMap_.cend())
   {
-    auto errorList = itm->second->getErrors();
+    auto errorList = itm->second->getMessages(BaseContext::ERROR_MESSAGE);
     errors.insert(errorList.cbegin(), errorList.cend());
   }
 
   auto itg = gridContextMap_.find(analysisHashCode);
   if(itg != gridContextMap_.cend())
   {
-    auto errorList = itg->second->getErrors();
+    auto errorList = itg->second->getMessages(BaseContext::ERROR_MESSAGE);
     errors.insert(errorList.cbegin(), errorList.cend());
   }
 

--- a/src/terrama2/services/analysis/core/MonitoredObjectContext.cpp
+++ b/src/terrama2/services/analysis/core/MonitoredObjectContext.cpp
@@ -411,7 +411,7 @@ terrama2::services::analysis::core::MonitoredObjectContext::getMonitoredObjectCo
       {
         QString errMsg(QObject::tr("Could not recover monitored object dataset."));
 
-        addError(errMsg.toStdString());
+        addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
         return contextDataSeries;
       }
 

--- a/src/terrama2/services/analysis/core/dcp/Operator.cpp
+++ b/src/terrama2/services/analysis/core/dcp/Operator.cpp
@@ -250,18 +250,18 @@ double terrama2::services::analysis::core::dcp::zonal::operatorImpl(StatisticOpe
       }
       catch(const terrama2::Exception& e)
       {
-        context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+        context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
         exceptionOccurred = true;
       }
       catch(const std::exception& e)
       {
-        context->addError(e.what());
+        context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
         exceptionOccurred = true;
       }
       catch(...)
       {
         QString errMsg = QObject::tr("An unknown exception occurred.");
-        context->addError(errMsg.toStdString());
+        context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
         exceptionOccurred = true;
       }
 
@@ -279,18 +279,18 @@ double terrama2::services::analysis::core::dcp::zonal::operatorImpl(StatisticOpe
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/dcp/Operator.cpp
+++ b/src/terrama2/services/analysis/core/dcp/Operator.cpp
@@ -99,12 +99,9 @@ double terrama2::services::analysis::core::dcp::zonal::operatorImpl(StatisticOpe
 
   try
   {
-    // In case an error has already occurred, there is nothing to be done
-    if(!context->getErrors().empty())
-    {
+    // In case an log has already occurred, there is nothing to do.
+    if(context->hasError())
       return std::nan("");
-    }
-
 
     std::vector<DataSetId> vecDCPIds;
     terrama2::services::analysis::core::python::pythonToVector<DataSetId>(ids, vecDCPIds);
@@ -149,8 +146,6 @@ double terrama2::services::analysis::core::dcp::zonal::operatorImpl(StatisticOpe
     {
       terrama2::services::analysis::core::python::OperatorLock operatorLock;
 
-
-
       try
       {
 
@@ -190,7 +185,7 @@ double terrama2::services::analysis::core::dcp::zonal::operatorImpl(StatisticOpe
               {
                 auto property = dcpContextDataSeries->series.teDataSetType->getProperty(attribute);
 
-                // only operation COUNT can be done without attribute.
+                // only operation COUNT can be result without attribute.
                 if(!property && statisticOperation != StatisticOperation::COUNT)
                 {
                   QString errMsg(QObject::tr("Invalid attribute name"));

--- a/src/terrama2/services/analysis/core/dcp/Operator.cpp
+++ b/src/terrama2/services/analysis/core/dcp/Operator.cpp
@@ -99,7 +99,7 @@ double terrama2::services::analysis::core::dcp::zonal::operatorImpl(StatisticOpe
 
   try
   {
-    // In case an log has already occurred, there is nothing to do.
+    // In case an error has already occurred, there is nothing to do.
     if(context->hasError())
       return std::nan("");
 
@@ -185,7 +185,7 @@ double terrama2::services::analysis::core::dcp::zonal::operatorImpl(StatisticOpe
               {
                 auto property = dcpContextDataSeries->series.teDataSetType->getProperty(attribute);
 
-                // only operation COUNT can be result without attribute.
+                // only operation COUNT can be done without attribute.
                 if(!property && statisticOperation != StatisticOperation::COUNT)
                 {
                   QString errMsg(QObject::tr("Invalid attribute name"));

--- a/src/terrama2/services/analysis/core/dcp/history/Operator.cpp
+++ b/src/terrama2/services/analysis/core/dcp/history/Operator.cpp
@@ -91,7 +91,7 @@ double terrama2::services::analysis::core::dcp::zonal::history::operatorImpl(Sta
 
   try
   {
-    // In case an log has already occurred, there is nothing to do.
+    // In case an error has already occurred, there is nothing to do.
     if(context->hasError())
       return std::nan("");
 
@@ -168,7 +168,7 @@ double terrama2::services::analysis::core::dcp::zonal::history::operatorImpl(Sta
             {
               auto property = contextDataSeries->series.teDataSetType->getProperty(attribute);
 
-              // only operation COUNT can be result without attribute.
+              // only operation COUNT can be done without attribute.
               if(!property && statisticOperation != StatisticOperation::COUNT)
               {
                 QString errMsg(QObject::tr("Invalid attribute name"));

--- a/src/terrama2/services/analysis/core/dcp/history/Operator.cpp
+++ b/src/terrama2/services/analysis/core/dcp/history/Operator.cpp
@@ -91,11 +91,9 @@ double terrama2::services::analysis::core::dcp::zonal::history::operatorImpl(Sta
 
   try
   {
-    // In case an error has already occurred, there is nothing to be done
-    if(!context->getErrors().empty())
-    {
+    // In case an log has already occurred, there is nothing to do.
+    if(context->hasError())
       return std::nan("");
-    }
 
     std::vector<DataSetId> vecDCPIds;
     terrama2::services::analysis::core::python::pythonToVector<DataSetId>(ids, vecDCPIds);
@@ -170,7 +168,7 @@ double terrama2::services::analysis::core::dcp::zonal::history::operatorImpl(Sta
             {
               auto property = contextDataSeries->series.teDataSetType->getProperty(attribute);
 
-              // only operation COUNT can be done without attribute.
+              // only operation COUNT can be result without attribute.
               if(!property && statisticOperation != StatisticOperation::COUNT)
               {
                 QString errMsg(QObject::tr("Invalid attribute name"));

--- a/src/terrama2/services/analysis/core/dcp/history/Operator.cpp
+++ b/src/terrama2/services/analysis/core/dcp/history/Operator.cpp
@@ -211,18 +211,18 @@ double terrama2::services::analysis::core::dcp::zonal::history::operatorImpl(Sta
       }
       catch(const terrama2::Exception& e)
       {
-        context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+        context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
         exceptionOccurred = true;
       }
       catch(const std::exception& e)
       {
-        context->addError(e.what());
+        context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
         exceptionOccurred = true;
       }
       catch(...)
       {
         QString errMsg = QObject::tr("An unknown exception occurred.");
-        context->addError(errMsg.toStdString());
+        context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
         exceptionOccurred = true;
       }
 
@@ -245,18 +245,18 @@ double terrama2::services::analysis::core::dcp::zonal::history::operatorImpl(Sta
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/dcp/influence/Operator.cpp
+++ b/src/terrama2/services/analysis/core/dcp/influence/Operator.cpp
@@ -90,14 +90,14 @@ std::vector<DataSetId> terrama2::services::analysis::core::dcp::zonal::influence
   if(dataSeriesName.empty())
   {
     QString errMsg(QObject::tr("Invalid data series name"));
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return vecIds;
   }
 
   if(attributeList.empty())
   {
     QString errMsg(QObject::tr("Empty attribute list"));
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return vecIds;
   }
 
@@ -167,20 +167,20 @@ std::vector<DataSetId> terrama2::services::analysis::core::dcp::zonal::influence
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError( boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     vecIds.clear();
     return vecIds;
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     vecIds.clear();
     return vecIds;
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     vecIds.clear();
     return vecIds;
   }
@@ -218,7 +218,7 @@ std::vector<DataSetId> terrama2::services::analysis::core::dcp::zonal::influence
   if(dataSeriesName.empty())
   {
     QString errMsg(QObject::tr("Invalid data series name"));
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return vecIds;
   }
 
@@ -285,20 +285,20 @@ std::vector<DataSetId> terrama2::services::analysis::core::dcp::zonal::influence
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError( boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     vecIds.clear();
     return vecIds;
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     vecIds.clear();
     return vecIds;
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     vecIds.clear();
     return vecIds;
   }

--- a/src/terrama2/services/analysis/core/dcp/influence/Operator.cpp
+++ b/src/terrama2/services/analysis/core/dcp/influence/Operator.cpp
@@ -83,11 +83,9 @@ std::vector<DataSetId> terrama2::services::analysis::core::dcp::zonal::influence
   }
 
 
-  // In case an error has already occurred, there is nothing to be done
-  if(!context->getErrors().empty())
-  {
+  // In case an log has already occurred, there is nothing to do.
+  if(context->hasError())
     return vecIds;
-  }
 
   if(dataSeriesName.empty())
   {
@@ -211,8 +209,8 @@ std::vector<DataSetId> terrama2::services::analysis::core::dcp::zonal::influence
   }
 
 
-  // In case an error has already occurred, there is nothing to be done
-  if(!context->getErrors().empty())
+  // In case an error has already occurred, there is nothing to do.
+  if(context->hasError())
   {
     return vecIds;
   }

--- a/src/terrama2/services/analysis/core/dcp/influence/Operator.cpp
+++ b/src/terrama2/services/analysis/core/dcp/influence/Operator.cpp
@@ -83,7 +83,7 @@ std::vector<DataSetId> terrama2::services::analysis::core::dcp::zonal::influence
   }
 
 
-  // In case an log has already occurred, there is nothing to do.
+  // In case an error has already occurred, there is nothing to do.
   if(context->hasError())
     return vecIds;
 

--- a/src/terrama2/services/analysis/core/grid/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/Operator.cpp
@@ -89,8 +89,8 @@ double terrama2::services::analysis::core::grid::sample(const std::string& dataS
 
   try
   {
-    // In case an error has already occurred, there is nothing to be done
-    if(!context->getErrors().empty())
+    // In case an error has already occurred, there is nothing to do.
+    if(context->hasError())
     {
       return std::nan("");
     }

--- a/src/terrama2/services/analysis/core/grid/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/Operator.cpp
@@ -156,18 +156,18 @@ double terrama2::services::analysis::core::grid::sample(const std::string& dataS
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/grid/history/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/history/Operator.cpp
@@ -148,18 +148,18 @@ std::vector<double> terrama2::services::analysis::core::grid::history::sample(co
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return {};
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     return {};
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return {};
   }
 }
@@ -247,18 +247,18 @@ double terrama2::services::analysis::core::grid::history::operatorImpl(terrama2:
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/grid/history/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/history/Operator.cpp
@@ -76,8 +76,8 @@ std::vector<double> terrama2::services::analysis::core::grid::history::sample(co
 
   try
   {
-    // In case an error has already occurred, there is nothing to be done
-    if(!context->getErrors().empty())
+// In case an error has already occurred, there is nothing to do.
+    if(context->hasError())
     {
       return {};
     }
@@ -202,8 +202,8 @@ double terrama2::services::analysis::core::grid::history::operatorImpl(terrama2:
 
   try
   {
-    // In case an error has already occurred, there is nothing to be done
-    if(!context->getErrors().empty())
+// In case an error has already occurred, there is nothing to do.
+    if(context->hasError())
     {
       return std::nan("");
     }

--- a/src/terrama2/services/analysis/core/grid/zonal/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/Operator.cpp
@@ -101,8 +101,8 @@ double terrama2::services::analysis::core::grid::zonal::operatorImpl(terrama2::s
   bool exceptionOccurred = false;
   try
   {
-    // In case an error has already occurred, there is nothing to be done
-    if(!context->getErrors().empty())
+    // In case an error has already occurred, there is nothing to do.
+    if(context->hasError())
     {
       return std::nan("");
     }

--- a/src/terrama2/services/analysis/core/grid/zonal/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/Operator.cpp
@@ -199,18 +199,18 @@ double terrama2::services::analysis::core::grid::zonal::operatorImpl(terrama2::s
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/grid/zonal/forecast/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/forecast/Operator.cpp
@@ -63,7 +63,7 @@ double terrama2::services::analysis::core::grid::zonal::forecast::operatorImpl( 
 //  }
 //  catch (const terrama2::core::VerifyException&)
 //  {
-//    contextManager.addError(cache.analysisHashCode, QObject::tr("Use of invalid operator for analysis %1.").arg(analysis->id).toStdString());
+//    contextManager.addLogMessage(cache.analysisHashCode, QObject::tr("Use of invalid operator for analysis %1.").arg(analysis->id).toStdString());
 //    return NAN;
 //  }
 
@@ -203,18 +203,18 @@ double terrama2::services::analysis::core::grid::zonal::forecast::operatorImpl( 
 //  }
 //  catch(const terrama2::Exception& e)
 //  {
-//    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+//    context->addLogMessage(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
 //    return NAN;
 //  }
 //  catch(const std::exception& e)
 //  {
-//    context->addError(e.what());
+//    context->addLogMessage(e.what());
 //    return NAN;
 //  }
 //  catch(...)
 //  {
 //    QString errMsg = QObject::tr("An unknown exception occurred.");
-//    context->addError(errMsg.toStdString());
+//    context->addLogMessage(errMsg.toStdString());
 //    return NAN;
 //  }
 }

--- a/src/terrama2/services/analysis/core/grid/zonal/history/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/history/Operator.cpp
@@ -72,8 +72,8 @@ int terrama2::services::analysis::core::grid::zonal::history::num(const std::str
 
   try
   {
-    // In case an error has already occurred, there is nothing to be done
-    if(!context->getErrors().empty())
+    // In case an log has already occurred, there is nothing to do.
+    if(context->hasError())
     {
       return std::nan("");
     }
@@ -187,8 +187,8 @@ boost::python::list terrama2::services::analysis::core::grid::zonal::history::li
 
   try
   {
-    // In case an error has already occurred, there is nothing to be done
-    if(!context->getErrors().empty())
+    // In case an error has already occurred, there is nothing to do.
+    if(context->hasError())
     {
       return {};
     }

--- a/src/terrama2/services/analysis/core/grid/zonal/history/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/history/Operator.cpp
@@ -137,18 +137,18 @@ int terrama2::services::analysis::core::grid::zonal::history::num(const std::str
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }
@@ -273,18 +273,18 @@ boost::python::list terrama2::services::analysis::core::grid::zonal::history::li
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return {};
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     return {};
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return {};
   }
 }

--- a/src/terrama2/services/analysis/core/grid/zonal/history/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/history/Operator.cpp
@@ -72,7 +72,7 @@ int terrama2::services::analysis::core::grid::zonal::history::num(const std::str
 
   try
   {
-    // In case an log has already occurred, there is nothing to do.
+    // In case an error has already occurred, there is nothing to do.
     if(context->hasError())
     {
       return std::nan("");

--- a/src/terrama2/services/analysis/core/grid/zonal/history/accum/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/history/accum/Operator.cpp
@@ -222,18 +222,18 @@ double terrama2::services::analysis::core::grid::zonal::history::accum::operator
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/grid/zonal/history/accum/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/history/accum/Operator.cpp
@@ -201,14 +201,11 @@ double terrama2::services::analysis::core::grid::zonal::history::accum::operator
 
   try
   {
-    // In case an error has already occurred, there is nothing to be done
-    if(!context->getErrors().empty())
+    // In case an error has already occurred, there is nothing to do.
+    if(context->hasError())
       return std::nan("");
 
     auto valuesMap = getAccumulatedMap(dataSeriesName, dateDiscardBefore, dateDiscardAfter, band, buffer, context, cache);
-
-    if(exceptionOccurred)
-      return std::nan("");
 
     if(valuesMap.empty() && statisticOperation != StatisticOperation::COUNT)
     {

--- a/src/terrama2/services/analysis/core/grid/zonal/history/prec/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/history/prec/Operator.cpp
@@ -89,8 +89,8 @@ double terrama2::services::analysis::core::grid::zonal::history::prec::operatorI
 
   try
   {
-    // In case an error has already occurred, there is nothing to be done
-    if(!context->getErrors().empty())
+    // In case an error has already occurred, there is nothing to do.
+    if(context->hasError())
       return std::nan("");
 
     auto valuesMap = accum::getAccumulatedMap(dataSeriesName, dateDiscardBefore, dateDiscardAfter, band, buffer, context, cache);

--- a/src/terrama2/services/analysis/core/grid/zonal/history/prec/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/history/prec/Operator.cpp
@@ -112,18 +112,18 @@ double terrama2::services::analysis::core::grid::zonal::history::prec::operatorI
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/occurrence/Operator.cpp
+++ b/src/terrama2/services/analysis/core/occurrence/Operator.cpp
@@ -86,8 +86,8 @@ double terrama2::services::analysis::core::occurrence::operatorImpl(StatisticOpe
 
   try
   {
-    // In case an error has already occurred, there is nothing to be done
-    if(!context->getErrors().empty())
+    // In case an error has already occurred, there is nothing to do.
+    if(context->hasError())
     {
       return std::nan("");
     }
@@ -193,7 +193,7 @@ double terrama2::services::analysis::core::occurrence::operatorImpl(StatisticOpe
             {
               auto property = contextDataSeries->series.teDataSetType->getProperty(attribute);
 
-              // only operation COUNT can be done without attribute.
+              // only operation COUNT can be result without attribute.
               if(!property && statisticOperation != StatisticOperation::COUNT)
               {
                 QString errMsg(QObject::tr("Invalid attribute name"));

--- a/src/terrama2/services/analysis/core/occurrence/Operator.cpp
+++ b/src/terrama2/services/analysis/core/occurrence/Operator.cpp
@@ -193,7 +193,7 @@ double terrama2::services::analysis::core::occurrence::operatorImpl(StatisticOpe
             {
               auto property = contextDataSeries->series.teDataSetType->getProperty(attribute);
 
-              // only operation COUNT can be result without attribute.
+              // only operation COUNT can be done without attribute.
               if(!property && statisticOperation != StatisticOperation::COUNT)
               {
                 QString errMsg(QObject::tr("Invalid attribute name"));

--- a/src/terrama2/services/analysis/core/occurrence/Operator.cpp
+++ b/src/terrama2/services/analysis/core/occurrence/Operator.cpp
@@ -310,18 +310,18 @@ double terrama2::services::analysis::core::occurrence::operatorImpl(StatisticOpe
       }
       catch(const terrama2::Exception& e)
       {
-        context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+        context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
         exceptionOccurred = true;
       }
       catch(const std::exception& e)
       {
-        context->addError(e.what());
+        context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
         exceptionOccurred = true;
       }
       catch(...)
       {
         QString errMsg = QObject::tr("An unknown exception occurred.");
-        context->addError(errMsg.toStdString());
+        context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
         exceptionOccurred = true;
       }
 
@@ -341,18 +341,18 @@ double terrama2::services::analysis::core::occurrence::operatorImpl(StatisticOpe
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/python/PythonInterpreter.cpp
+++ b/src/terrama2/services/analysis/core/python/PythonInterpreter.cpp
@@ -98,7 +98,7 @@ void terrama2::services::analysis::core::python::runMonitoredObjectScript(PyThre
   if(!state)
   {
     QString errMsg = QObject::tr("Invalid thread state for python interpreter.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return;
   }
 
@@ -163,20 +163,20 @@ void terrama2::services::analysis::core::python::runMonitoredObjectScript(PyThre
   catch(const error_already_set&)
   {
     std::string errMsg = extractException();
-    context->addError(errMsg);
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg);
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
   }
 }
 
@@ -188,7 +188,7 @@ void terrama2::services::analysis::core::python::runScriptGridAnalysis(PyThreadS
   if(!state)
   {
     QString errMsg = QObject::tr("Invalid thread state for python interpreter.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return;
   }
 
@@ -262,20 +262,20 @@ void terrama2::services::analysis::core::python::runScriptGridAnalysis(PyThreadS
   catch(error_already_set)
   {
     std::string errMsg = extractException();
-    context->addError(errMsg);
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg);
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
   }
 
   PyThreadState_Swap(previousState);
@@ -310,7 +310,7 @@ void terrama2::services::analysis::core::python::runScriptDCPAnalysis(PyThreadSt
   catch(error_already_set)
   {
     std::string errMsg = extractException();
-    context->addError(errMsg);
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg);
   }
 }
 
@@ -344,18 +344,18 @@ void terrama2::services::analysis::core::python::addValue(const std::string& att
   }
   catch(const terrama2::Exception& e)
   {
-    context->addError(boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return;
   }
   catch(const std::exception& e)
   {
-    context->addError(e.what());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
     return;
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addError(errMsg.toStdString());
+    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
     return;
   }
 

--- a/src/terrama2/services/appserver/main.cpp
+++ b/src/terrama2/services/appserver/main.cpp
@@ -252,7 +252,7 @@ int main(int argc, char* argv[])
   }
   catch(...)
   {
-    TERRAMA2_LOG_ERROR() << QObject::tr("\n\nUnkown Exception...\n");
+    TERRAMA2_LOG_ERROR() << QObject::tr("\n\nUnknown Exception...\n");
   }
 
   return 0;

--- a/src/terrama2/services/collector/core/Service.cpp
+++ b/src/terrama2/services/collector/core/Service.cpp
@@ -202,8 +202,10 @@ void terrama2::services::collector::core::Service::collect(CollectorId collector
     auto dataMap = dataAccessor->getSeries(filter, remover);
     if(dataMap.empty())
     {
-      logger->result(CollectorLogger::ERROR, nullptr, logId);
-      TERRAMA2_LOG_WARNING() << tr("No data to collect.");
+      QString errMsg = tr("No data to collect.");
+      logger->result(CollectorLogger::DONE, nullptr, logId);
+      logger->log(CollectorLogger::WARNING_MESSAGE, errMsg.toStdString(), logId);
+      TERRAMA2_LOG_WARNING() << errMsg;
 
       notifyWaitQueue(collectorId);
       sendProcessFinishedSignal(collectorId, false);
@@ -362,7 +364,7 @@ void terrama2::services::collector::core::Service::removeCollector(CollectorId c
   }
   catch(...)
   {
-    TERRAMA2_LOG_ERROR() << tr("Unknown log");
+    TERRAMA2_LOG_ERROR() << tr("Unknown error");
     TERRAMA2_LOG_INFO() << tr("Could not remove collector: %1.").arg(collectorId);
   }
 }

--- a/src/terrama2/services/collector/core/Service.cpp
+++ b/src/terrama2/services/collector/core/Service.cpp
@@ -202,7 +202,7 @@ void terrama2::services::collector::core::Service::collect(CollectorId collector
     auto dataMap = dataAccessor->getSeries(filter, remover);
     if(dataMap.empty())
     {
-      logger->done(nullptr, logId);
+      logger->result(CollectorLogger::ERROR, nullptr, logId);
       TERRAMA2_LOG_WARNING() << tr("No data to collect.");
 
       notifyWaitQueue(collectorId);
@@ -235,7 +235,7 @@ void terrama2::services::collector::core::Service::collect(CollectorId collector
 
     TERRAMA2_LOG_INFO() << tr("Data from collector %1 collected successfully.").arg(collectorId);
 
-    logger->done(lastDateTime, logId);
+    logger->result(CollectorLogger::DONE, lastDateTime, logId);
 
 
     sendProcessFinishedSignal(collectorId, true);
@@ -249,7 +249,10 @@ void terrama2::services::collector::core::Service::collect(CollectorId collector
     TERRAMA2_LOG_INFO() << tr("Collection for collector %1 finished with error(s).").arg(collectorId);
 
     if(logId != 0)
-      logger->error(errMsg.toStdString(), logId);
+    {
+      logger->log(CollectorLogger::ERROR_MESSAGE, errMsg.toStdString(), logId);
+      logger->result(CollectorLogger::ERROR, nullptr, logId);
+    }
   }
   catch(const boost::exception& e)
   {
@@ -258,7 +261,10 @@ void terrama2::services::collector::core::Service::collect(CollectorId collector
     TERRAMA2_LOG_INFO() << tr("Collection for collector %1 finished with error(s).").arg(collectorId);
 
     if(logId != 0)
-      logger->error(errMsg, logId);
+    {
+      logger->log(CollectorLogger::ERROR_MESSAGE, errMsg, logId);
+      logger->result(CollectorLogger::ERROR, nullptr, logId);
+    }
   }
   catch(const std::exception& e)
   {
@@ -266,16 +272,22 @@ void terrama2::services::collector::core::Service::collect(CollectorId collector
     TERRAMA2_LOG_INFO() << tr("Collection for collector %1 finished with error(s).").arg(collectorId);
 
     if(logId != 0)
-      logger->error(e.what(), logId);
+    {
+      logger->log(CollectorLogger::ERROR_MESSAGE, e.what(), logId);
+      logger->result(CollectorLogger::ERROR, nullptr, logId);
+    }
   }
   catch(...)
   {
-    QString errMsg = tr("Unkown error.");
+    QString errMsg = tr("Unknown error.");
     TERRAMA2_LOG_ERROR() << errMsg;
     TERRAMA2_LOG_INFO() << tr("Collection for collector %1 finished with error(s).").arg(collectorId);
 
     if(logId != 0)
-      logger->error(errMsg.toStdString(), logId);
+    {
+      logger->log(CollectorLogger::ERROR_MESSAGE, errMsg.toStdString(), logId);
+      logger->result(CollectorLogger::ERROR, nullptr, logId);
+    }
   }
 
   sendProcessFinishedSignal(collectorId, false);
@@ -350,7 +362,7 @@ void terrama2::services::collector::core::Service::removeCollector(CollectorId c
   }
   catch(...)
   {
-    TERRAMA2_LOG_ERROR() << tr("Unknown error");
+    TERRAMA2_LOG_ERROR() << tr("Unknown log");
     TERRAMA2_LOG_INFO() << tr("Could not remove collector: %1.").arg(collectorId);
   }
 }

--- a/src/terrama2/services/view/core/Service.cpp
+++ b/src/terrama2/services/view/core/Service.cpp
@@ -186,7 +186,7 @@ void terrama2::services::view::core::Service::removeView(ViewId viewId) noexcept
   }
   catch(...)
   {
-    TERRAMA2_LOG_ERROR() << tr("Unknown log");
+    TERRAMA2_LOG_ERROR() << tr("Unknown error");
     TERRAMA2_LOG_INFO() << tr("Could not remove view: %1.").arg(viewId);
   }
 }
@@ -261,7 +261,7 @@ void terrama2::services::view::core::Service::viewJob(ViewId viewId,
 
     TERRAMA2_LOG_INFO() << tr("View %1 generated successfully.").arg(viewId);
 
-    logger->result(ViewLogger::ERROR, terrama2::core::TimeUtils::nowUTC(), logId);
+    logger->result(ViewLogger::DONE, terrama2::core::TimeUtils::nowUTC(), logId);
 
     sendProcessFinishedSignal(viewId, true, jsonAnswer);
     notifyWaitQueue(viewId);

--- a/src/terrama2/services/view/core/Service.cpp
+++ b/src/terrama2/services/view/core/Service.cpp
@@ -186,7 +186,7 @@ void terrama2::services::view::core::Service::removeView(ViewId viewId) noexcept
   }
   catch(...)
   {
-    TERRAMA2_LOG_ERROR() << tr("Unknown error");
+    TERRAMA2_LOG_ERROR() << tr("Unknown log");
     TERRAMA2_LOG_INFO() << tr("Could not remove view: %1.").arg(viewId);
   }
 }
@@ -261,7 +261,7 @@ void terrama2::services::view::core::Service::viewJob(ViewId viewId,
 
     TERRAMA2_LOG_INFO() << tr("View %1 generated successfully.").arg(viewId);
 
-    logger->done(terrama2::core::TimeUtils::nowUTC(), logId);
+    logger->result(ViewLogger::ERROR, terrama2::core::TimeUtils::nowUTC(), logId);
 
     sendProcessFinishedSignal(viewId, true, jsonAnswer);
     notifyWaitQueue(viewId);
@@ -275,7 +275,7 @@ void terrama2::services::view::core::Service::viewJob(ViewId viewId,
     TERRAMA2_LOG_INFO() << QObject::tr("Build of view %1 finished with error(s).").arg(viewId);
 
     if(logId != 0)
-      logger->error(errMsg, logId);
+      logger->log(ViewLogger::ERROR_MESSAGE, errMsg, logId);
   }
   catch(const boost::exception& e)
   {
@@ -284,7 +284,7 @@ void terrama2::services::view::core::Service::viewJob(ViewId viewId,
     TERRAMA2_LOG_INFO() << QObject::tr("Build of view %1 finished with error(s).").arg(viewId);
 
     if(logId != 0)
-      logger->error(errMsg, logId);
+      logger->log(ViewLogger::ERROR_MESSAGE, errMsg, logId);
   }
   catch(const std::exception& e)
   {
@@ -293,16 +293,16 @@ void terrama2::services::view::core::Service::viewJob(ViewId viewId,
     TERRAMA2_LOG_INFO() << QObject::tr("Build of view %1 finished with error(s).").arg(viewId);
 
     if(logId != 0)
-      logger->error(errMsg, logId);
+      logger->log(ViewLogger::ERROR_MESSAGE, errMsg, logId);
   }
   catch(...)
   {
-    std::string errMsg = "Unkown error.";
-    TERRAMA2_LOG_ERROR() << QObject::tr("Unkown error.");
+    std::string errMsg = "Unknown error.";
+    TERRAMA2_LOG_ERROR() << QObject::tr("Unknown error.");
     TERRAMA2_LOG_INFO() << QObject::tr("Build of view %1 finished with error(s).").arg(viewId);
 
     if(logId != 0)
-      logger->error(errMsg, logId);
+      logger->log(ViewLogger::ERROR_MESSAGE, errMsg, logId);
   }
 
   sendProcessFinishedSignal(viewId, false);

--- a/src/terrama2/services/view/core/data-access/Geoserver.cpp
+++ b/src/terrama2/services/view/core/data-access/Geoserver.cpp
@@ -772,7 +772,7 @@ QJsonObject terrama2::services::view::core::GeoServer::generateLayers(const View
     terrama2::core::DataSeriesPtr inputDataSeries = dataSeriesProvider.first;
     terrama2::core::DataProviderPtr inputDataProvider = dataSeriesProvider.second;
 
-    // Check if the view can be result by the maps server
+    // Check if the view can be done by the maps server
     DataProviderType dataProviderType = inputDataProvider->dataProviderType;
 
     if(dataProviderType != "POSTGIS" && dataProviderType != "FILE")

--- a/src/terrama2/services/view/core/data-access/Geoserver.cpp
+++ b/src/terrama2/services/view/core/data-access/Geoserver.cpp
@@ -772,7 +772,7 @@ QJsonObject terrama2::services::view::core::GeoServer::generateLayers(const View
     terrama2::core::DataSeriesPtr inputDataSeries = dataSeriesProvider.first;
     terrama2::core::DataProviderPtr inputDataProvider = dataSeriesProvider.second;
 
-    // Check if the view can be done by the maps server
+    // Check if the view can be result by the maps server
     DataProviderType dataProviderType = inputDataProvider->dataProviderType;
 
     if(dataProviderType != "POSTGIS" && dataProviderType != "FILE")
@@ -916,7 +916,7 @@ QJsonObject terrama2::services::view::core::GeoServer::generateLayers(const View
 
             if(id == dataset->format.end() || foreing == dataset->format.end())
             {
-              logger->error("Data to join not informed.", logId);
+              logger->log(ViewLogger::ERROR_MESSAGE, "Data to join not informed.", logId);
               TERRAMA2_LOG_ERROR() << QObject::tr("Cannot join data from a different DB source!");
               continue;
             }
@@ -930,14 +930,14 @@ QJsonObject terrama2::services::view::core::GeoServer::generateLayers(const View
                || monitoredObjectUrl.port() != url.port()
                || monitoredObjectUrl.path().section("/", 1, 1) != url.path().section("/", 1, 1))
             {
-              logger->error("Data to join is in a different DB.", logId);
+              logger->log(ViewLogger::ERROR_MESSAGE, "Data to join is in a different DB.", logId);
               TERRAMA2_LOG_ERROR() << QObject::tr("Cannot join data from a different DB source!");
               continue;
             }
 
             if(monitoredObjectDataSeries->datasetList.empty())
             {
-              logger->error("No join data.", logId);
+              logger->log(ViewLogger::ERROR_MESSAGE, "No join data.", logId);
               TERRAMA2_LOG_ERROR() << QObject::tr("Cannot join data from a different DB source!");
               continue;
             }
@@ -976,7 +976,7 @@ QJsonObject terrama2::services::view::core::GeoServer::generateLayers(const View
     }
     else
     {
-      logger->info("No data to register.", logId);
+      logger->log(ViewLogger::WARNING_MESSAGE, "No data to register.", logId);
       TERRAMA2_LOG_WARNING() << QObject::tr("No data to register in maps server.");
       continue;
     }

--- a/src/unittest/core/TsProcessLogger.cpp
+++ b/src/unittest/core/TsProcessLogger.cpp
@@ -31,7 +31,6 @@
 #include <terrama2/core/Typedef.hpp>
 #include <terrama2/core/utility/TimeUtils.hpp>
 #include <terrama2/Exception.hpp>
-
 #include "TsProcessLogger.hpp"
 #include "TestLogger.hpp"
 
@@ -41,22 +40,22 @@ void TsProcessLogger::testProcessLogger()
 {
   try
   {
-  TestLogger log;
+    TestLogger log;
 
-  RegisterId registerID = log.start(1);
+    RegisterId registerID = log.start(1);
 
-  log.logValue("tag1", "value1", registerID);
-  log.logValue("tag2", "value2", registerID);
-  log.logValue("tag1", "value3", registerID);
-  log.logValue("tag2", "value4", registerID);
-    log.log(ERROR_MESSAGE, "Unit Test Error", registerID);
-    log.log(ERROR_MESSAGE, "Unit Test second Error", registerID);
-  log.info("Unit Test Info", registerID);
-  log.info("Unit Test seconde Info", registerID);
+    log.logValue("tag1", "value1", registerID);
+    log.logValue("tag2", "value2", registerID);
+    log.logValue("tag1", "value3", registerID);
+    log.logValue("tag2", "value4", registerID);
+    log.log(TestLogger::ERROR_MESSAGE, "Unit Test Error", registerID);
+    log.log(TestLogger::ERROR_MESSAGE, "Unit Test second Error", registerID);
+    log.log(TestLogger::INFO_MESSAGE, "Unit Test Info", registerID);
+    log.log(TestLogger::INFO_MESSAGE, "Unit Test seconde Info", registerID);
 
-  std::shared_ptr< te::dt::TimeInstantTZ > dataTime = terrama2::core::TimeUtils::nowUTC();
+    std::shared_ptr< te::dt::TimeInstantTZ > dataTime = terrama2::core::TimeUtils::nowUTC();
 
-    log.result(ERROR, dataTime, registerID);
+    log.result(terrama2::core::ProcessLogger::ERROR, dataTime, registerID);
   }
   catch(const terrama2::Exception& e)
   {

--- a/src/unittest/core/TsProcessLogger.cpp
+++ b/src/unittest/core/TsProcessLogger.cpp
@@ -49,14 +49,14 @@ void TsProcessLogger::testProcessLogger()
   log.logValue("tag2", "value2", registerID);
   log.logValue("tag1", "value3", registerID);
   log.logValue("tag2", "value4", registerID);
-  log.error("Unit Test Error", registerID);
-  log.error("Unit Test second Error", registerID);
+    log.log(ERROR_MESSAGE, "Unit Test Error", registerID);
+    log.log(ERROR_MESSAGE, "Unit Test second Error", registerID);
   log.info("Unit Test Info", registerID);
   log.info("Unit Test seconde Info", registerID);
 
   std::shared_ptr< te::dt::TimeInstantTZ > dataTime = terrama2::core::TimeUtils::nowUTC();
 
-  log.done(dataTime, registerID);
+    log.result(ERROR, dataTime, registerID);
   }
   catch(const terrama2::Exception& e)
   {


### PR DESCRIPTION
Using binary mask to overwrite CTL configuration for remote data
Refactoring logger class
Logging no data as warning
