### PR TITLE
Forecast operators and using error type in log messages

### DIFF
--- a/src/terrama2/core/utility/Utils.cpp
+++ b/src/terrama2/core/utility/Utils.cpp
@@ -471,8 +471,8 @@ std::string terrama2::core::getTimeInterval(terrama2::core::DataSetPtr dataset)
 {
   try
   {
-    auto interval{dataset->format.at("time_interval")};
-    auto unit{dataset->format.at("time_interval_unit")};
+    std::string interval{dataset->format.at("time_interval")};
+    std::string unit{dataset->format.at("time_interval_unit")};
 
     return interval+unit;
   }

--- a/src/terrama2/core/utility/Utils.cpp
+++ b/src/terrama2/core/utility/Utils.cpp
@@ -467,25 +467,14 @@ bool terrama2::core::isTemporal(terrama2::core::DataSetPtr dataset)
   }
 }
 
-std::string terrama2::core::getTimeIntervalUnit(terrama2::core::DataSetPtr dataset)
+std::string terrama2::core::getTimeInterval(terrama2::core::DataSetPtr dataset)
 {
   try
   {
-    return dataset->format.at("time_interval_unit");
-  }
-  catch(...)
-  {
-    QString errMsg = QObject::tr("Undefined tag for time interval unit in dataset: %1.").arg(dataset->id);
-    TERRAMA2_LOG_ERROR() << errMsg;
-    throw UndefinedTagException() << ErrorDescription(errMsg);
-  }
-}
+    auto interval{dataset->format.at("time_interval")};
+    auto unit{dataset->format.at("time_interval_unit")};
 
-double terrama2::core::getTimeInterval(terrama2::core::DataSetPtr dataset)
-{
-  try
-  {
-    return std::stod(dataset->format.at("time_interval"), nullptr);
+    return interval+unit;
   }
   catch(...)
   {
@@ -494,7 +483,6 @@ double terrama2::core::getTimeInterval(terrama2::core::DataSetPtr dataset)
     throw UndefinedTagException() << ErrorDescription(errMsg);
   }
 }
-
 
 std::string terrama2::core::getFolderMask(DataSetPtr dataSet, DataSeriesPtr dataSeries)
 {

--- a/src/terrama2/core/utility/Utils.cpp
+++ b/src/terrama2/core/utility/Utils.cpp
@@ -471,8 +471,8 @@ std::string terrama2::core::getTimeInterval(terrama2::core::DataSetPtr dataset)
 {
   try
   {
-    std::string interval{dataset->format.at("time_interval")};
-    std::string unit{dataset->format.at("time_interval_unit")};
+    std::string interval = dataset->format.at("time_interval");
+    std::string unit = dataset->format.at("time_interval_unit");
 
     return interval+unit;
   }

--- a/src/terrama2/core/utility/Utils.hpp
+++ b/src/terrama2/core/utility/Utils.hpp
@@ -141,14 +141,9 @@ namespace terrama2
     bool isTemporal(terrama2::core::DataSetPtr dataset);
 
     /*!
-      \brief Returns the value for the time interval unit property of the given dataset.
-    */
-    std::string getTimeIntervalUnit(terrama2::core::DataSetPtr dataset);
-
-    /*!
       \brief Returns the value for the time interval property of the given dataset.
     */
-    double getTimeInterval(terrama2::core::DataSetPtr dataset);
+    std::string getTimeInterval(terrama2::core::DataSetPtr dataset);
 
 
     /*!

--- a/src/terrama2/services/analysis/core/AnalysisExecutor.cpp
+++ b/src/terrama2/services/analysis/core/AnalysisExecutor.cpp
@@ -71,6 +71,7 @@ terrama2::services::analysis::core::AnalysisExecutor::AnalysisExecutor()
 {
   qRegisterMetaType<std::shared_ptr<te::dt::TimeInstantTZ>>("std::shared_ptr<te::dt::TimeInstantTZ>");
   qRegisterMetaType<uint32_t>("uint32_t");
+  qRegisterMetaType<uint32_t>("size_t");
 }
 
 
@@ -150,7 +151,7 @@ void terrama2::services::analysis::core::AnalysisExecutor::runAnalysis(DataManag
 
   try
   {
-    auto warnings = ContextManager::getInstance().getErrors(analysisHashCode);
+    auto warnings = ContextManager::getInstance().getMessages(analysisHashCode, BaseContext::MessageType::WARNING_MESSAGE);
     if(!warnings.empty())
     {
       for (auto warning: warnings)
@@ -159,7 +160,7 @@ void terrama2::services::analysis::core::AnalysisExecutor::runAnalysis(DataManag
       }
     }
 
-    auto errors = ContextManager::getInstance().getErrors(analysisHashCode);
+    auto errors = ContextManager::getInstance().getMessages(analysisHashCode, BaseContext::MessageType::ERROR_MESSAGE);
     if(!errors.empty())
     {
 
@@ -314,18 +315,18 @@ void terrama2::services::analysis::core::AnalysisExecutor::runMonitoredObjectAna
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f) { f.get(); });
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f) { f.get(); });
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f) { f.get(); });
   }
 
@@ -436,7 +437,7 @@ void terrama2::services::analysis::core::AnalysisExecutor::storeMonitoredObjectA
       if(!context->exists(datasetMO->id))
       {
         QString errMsg(QObject::tr("Could not recover monitored object dataset."));
-        context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+        context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
         return;
       }
 
@@ -445,14 +446,14 @@ void terrama2::services::analysis::core::AnalysisExecutor::storeMonitoredObjectA
       if(moDsContext->identifier.empty())
       {
         QString errMsg(QObject::tr("Monitored object identifier is empty."));
-        context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+        context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
         return;
       }
 
       if(!moDsContext->series.teDataSetType)
       {
         QString errMsg(QObject::tr("Invalid dataset type."));
-        context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+        context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
         return;
       }
 
@@ -468,14 +469,14 @@ void terrama2::services::analysis::core::AnalysisExecutor::storeMonitoredObjectA
   if(!found)
   {
     QString errMsg(QObject::tr("Could not find a monitored object dataseries."));
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return;
   }
 
   if(!identifierProperty)
   {
     QString errMsg(QObject::tr("Invalid monitored object attribute identifier."));
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return;
   }
 
@@ -580,7 +581,7 @@ void terrama2::services::analysis::core::AnalysisExecutor::runGridAnalysis(DataM
   if(!analysis->outputGridPtr)
   {
     QString errMsg = QObject::tr("Invalid output grid configuration.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return;
   }
 
@@ -667,29 +668,29 @@ void terrama2::services::analysis::core::AnalysisExecutor::runGridAnalysis(DataM
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f) { f.get(); });
   }
   catch(const boost::python::error_already_set&)
   {
     std::string errMsg = terrama2::services::analysis::core::python::extractException();
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg);
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg);
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f) { f.get(); });
   }
   catch(const boost::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::diagnostic_information(e));
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::diagnostic_information(e));
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f) { f.get(); });
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f) { f.get(); });
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     std::for_each(futures.begin(), futures.end(), [](std::future<void>& f){ f.get(); });
   }
 
@@ -808,18 +809,18 @@ void terrama2::services::analysis::core::AnalysisExecutor::storeGridAnalysisResu
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return;
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     return;
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred trying to store the results.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return;
   }
 }

--- a/src/terrama2/services/analysis/core/AnalysisExecutor.hpp
+++ b/src/terrama2/services/analysis/core/AnalysisExecutor.hpp
@@ -159,7 +159,7 @@ namespace terrama2
 
           signals:
             //! Signal to notify that a analysis execution has finished.
-            void analysisFinished(int, bool);
+            void analysisFinished(size_t, bool);
 
         };
 

--- a/src/terrama2/services/analysis/core/BaseContext.cpp
+++ b/src/terrama2/services/analysis/core/BaseContext.cpp
@@ -254,7 +254,7 @@ const std::set<std::string> terrama2::services::analysis::core::BaseContext::get
 
 bool terrama2::services::analysis::core::BaseContext::hasError() const
 {
-  auto it = logMessages_.find(ERROR_MESSAGE);
+  auto it = logMessages_.find(MessageType::ERROR_MESSAGE);
   if(it == logMessages_.end())
     return false;
 

--- a/src/terrama2/services/analysis/core/BaseContext.hpp
+++ b/src/terrama2/services/analysis/core/BaseContext.hpp
@@ -124,7 +124,7 @@ namespace terrama2
 
               \brief Possible status of logged messages.
             */
-            enum MessageType
+            enum class MessageType
             {
               ERROR_MESSAGE = 1,
               INFO_MESSAGE = 2,

--- a/src/terrama2/services/analysis/core/ContextManager.cpp
+++ b/src/terrama2/services/analysis/core/ContextManager.cpp
@@ -151,7 +151,7 @@ void terrama2::services::analysis::core::ContextManager::addError(const Analysis
   errorList.insert(error);
 }
 
-std::set<std::string> terrama2::services::analysis::core::ContextManager::getErrors(const AnalysisHashCode analysisHashCode) const
+std::set<std::string> terrama2::services::analysis::core::ContextManager::getMessages(const AnalysisHashCode analysisHashCode, BaseContext::MessageType messageType) const
 {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::set<std::string> errors;
@@ -162,14 +162,14 @@ std::set<std::string> terrama2::services::analysis::core::ContextManager::getErr
   auto itm = monitoredObjectContextMap_.find(analysisHashCode);
   if(itm != monitoredObjectContextMap_.cend())
   {
-    auto errorList = itm->second->getMessages(BaseContext::ERROR_MESSAGE);
+    auto errorList = itm->second->getMessages(messageType);
     errors.insert(errorList.cbegin(), errorList.cend());
   }
 
   auto itg = gridContextMap_.find(analysisHashCode);
   if(itg != gridContextMap_.cend())
   {
-    auto errorList = itg->second->getMessages(BaseContext::ERROR_MESSAGE);
+    auto errorList = itg->second->getMessages(messageType);
     errors.insert(errorList.cbegin(), errorList.cend());
   }
 

--- a/src/terrama2/services/analysis/core/ContextManager.hpp
+++ b/src/terrama2/services/analysis/core/ContextManager.hpp
@@ -32,6 +32,7 @@
 
 #include "Shared.hpp"
 #include "Analysis.hpp"
+#include "BaseContext.hpp"
 
 // TerraLib
 #include <terralib/common/Singleton.h>
@@ -65,7 +66,7 @@ namespace terrama2
             void clearContext(const AnalysisHashCode analysisHashCode);
 
             void addError(const AnalysisHashCode analysisHashCode, const std::string& error);
-            std::set<std::string> getErrors(const AnalysisHashCode analysisHashCode) const;
+            std::set<std::string> getMessages(const AnalysisHashCode analysisHashCode, terrama2::services::analysis::core::BaseContext::MessageType messageType) const;
 
 
           private:

--- a/src/terrama2/services/analysis/core/MonitoredObjectContext.cpp
+++ b/src/terrama2/services/analysis/core/MonitoredObjectContext.cpp
@@ -411,7 +411,7 @@ terrama2::services::analysis::core::MonitoredObjectContext::getMonitoredObjectCo
       {
         QString errMsg(QObject::tr("Could not recover monitored object dataset."));
 
-        addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+        addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
         return contextDataSeries;
       }
 

--- a/src/terrama2/services/analysis/core/dcp/Operator.cpp
+++ b/src/terrama2/services/analysis/core/dcp/Operator.cpp
@@ -247,18 +247,18 @@ double terrama2::services::analysis::core::dcp::zonal::operatorImpl(StatisticOpe
       }
       catch(const terrama2::Exception& e)
       {
-        context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+        context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
         exceptionOccurred = true;
       }
       catch(const std::exception& e)
       {
-        context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+        context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
         exceptionOccurred = true;
       }
       catch(...)
       {
         QString errMsg = QObject::tr("An unknown exception occurred.");
-        context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+        context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
         exceptionOccurred = true;
       }
 
@@ -276,18 +276,18 @@ double terrama2::services::analysis::core::dcp::zonal::operatorImpl(StatisticOpe
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/dcp/history/Operator.cpp
+++ b/src/terrama2/services/analysis/core/dcp/history/Operator.cpp
@@ -211,18 +211,18 @@ double terrama2::services::analysis::core::dcp::zonal::history::operatorImpl(Sta
       }
       catch(const terrama2::Exception& e)
       {
-        context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+        context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
         exceptionOccurred = true;
       }
       catch(const std::exception& e)
       {
-        context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+        context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
         exceptionOccurred = true;
       }
       catch(...)
       {
         QString errMsg = QObject::tr("An unknown exception occurred.");
-        context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+        context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
         exceptionOccurred = true;
       }
 
@@ -245,18 +245,18 @@ double terrama2::services::analysis::core::dcp::zonal::history::operatorImpl(Sta
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/dcp/influence/Operator.cpp
+++ b/src/terrama2/services/analysis/core/dcp/influence/Operator.cpp
@@ -92,14 +92,14 @@ std::vector< std::string > terrama2::services::analysis::core::dcp::zonal::influ
   if(dataSeriesName.empty())
   {
     QString errMsg(QObject::tr("Invalid data series name"));
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return vecDCP;
   }
 
   if(attributeList.empty())
   {
     QString errMsg(QObject::tr("Empty attribute list"));
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return vecDCP;
   }
 
@@ -169,20 +169,20 @@ std::vector< std::string > terrama2::services::analysis::core::dcp::zonal::influ
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     vecDCP.clear();
     return vecDCP;
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     vecDCP.clear();
     return vecDCP;
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     vecDCP.clear();
     return vecDCP;
   }
@@ -220,7 +220,7 @@ std::vector< std::string > terrama2::services::analysis::core::dcp::zonal::influ
   if(dataSeriesName.empty())
   {
     QString errMsg(QObject::tr("Invalid data series name"));
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return vecDCP;
   }
 
@@ -287,20 +287,20 @@ std::vector< std::string > terrama2::services::analysis::core::dcp::zonal::influ
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     vecDCP.clear();
     return vecDCP;
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     vecDCP.clear();
     return vecDCP;
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     vecDCP.clear();
     return vecDCP;
   }

--- a/src/terrama2/services/analysis/core/grid/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/Operator.cpp
@@ -150,18 +150,18 @@ double terrama2::services::analysis::core::grid::sample(const std::string& dataS
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/grid/history/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/history/Operator.cpp
@@ -142,18 +142,18 @@ std::vector<double> terrama2::services::analysis::core::grid::history::sample(co
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return {};
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     return {};
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return {};
   }
 }
@@ -241,18 +241,18 @@ double terrama2::services::analysis::core::grid::history::operatorImpl(terrama2:
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/grid/zonal/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/Operator.cpp
@@ -193,18 +193,18 @@ double terrama2::services::analysis::core::grid::zonal::operatorImpl(terrama2::s
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/grid/zonal/forecast/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/forecast/Operator.cpp
@@ -151,7 +151,7 @@ double terrama2::services::analysis::core::grid::zonal::forecast::operatorImpl( 
         if(!raster->getExtent()->intersects(*geomResult->getMBR()))
           continue;
 
-        auto intervalStr{terrama2::core::getTimeInterval(dataset)};
+        auto intervalStr = terrama2::core::getTimeInterval(dataset);
         double interval = terrama2::core::TimeUtils::convertTimeString(intervalStr, "SECOND", "h");
         double secondsToBefore = terrama2::core::TimeUtils::convertTimeString(dateDiscardBefore, "SECOND", "h");
         double secondsToAfter = terrama2::core::TimeUtils::convertTimeString(dateDiscardAfter, "SECOND", "h");

--- a/src/terrama2/services/analysis/core/grid/zonal/history/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/history/Operator.cpp
@@ -131,18 +131,18 @@ int terrama2::services::analysis::core::grid::zonal::history::num(const std::str
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }
@@ -261,18 +261,18 @@ boost::python::list terrama2::services::analysis::core::grid::zonal::history::li
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return {};
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     return {};
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return {};
   }
 }

--- a/src/terrama2/services/analysis/core/grid/zonal/history/accum/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/history/accum/Operator.cpp
@@ -216,18 +216,18 @@ double terrama2::services::analysis::core::grid::zonal::history::accum::operator
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/grid/zonal/history/prec/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/history/prec/Operator.cpp
@@ -112,18 +112,18 @@ double terrama2::services::analysis::core::grid::zonal::history::prec::operatorI
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/occurrence/Operator.cpp
+++ b/src/terrama2/services/analysis/core/occurrence/Operator.cpp
@@ -301,18 +301,18 @@ double terrama2::services::analysis::core::occurrence::operatorImpl(StatisticOpe
       }
       catch(const terrama2::Exception& e)
       {
-        context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+        context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
         exceptionOccurred = true;
       }
       catch(const std::exception& e)
       {
-        context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+        context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
         exceptionOccurred = true;
       }
       catch(...)
       {
         QString errMsg = QObject::tr("An unknown exception occurred.");
-        context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+        context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
         exceptionOccurred = true;
       }
 
@@ -332,18 +332,18 @@ double terrama2::services::analysis::core::occurrence::operatorImpl(StatisticOpe
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return std::nan("");
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     return std::nan("");
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return std::nan("");
   }
 }

--- a/src/terrama2/services/analysis/core/python/PythonInterpreter.cpp
+++ b/src/terrama2/services/analysis/core/python/PythonInterpreter.cpp
@@ -98,7 +98,7 @@ void terrama2::services::analysis::core::python::runMonitoredObjectScript(PyThre
   if(!state)
   {
     QString errMsg = QObject::tr("Invalid thread state for python interpreter.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return;
   }
 
@@ -163,20 +163,20 @@ void terrama2::services::analysis::core::python::runMonitoredObjectScript(PyThre
   catch(const error_already_set&)
   {
     std::string errMsg = extractException();
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg);
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg);
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
   }
 }
 
@@ -188,7 +188,7 @@ void terrama2::services::analysis::core::python::runScriptGridAnalysis(PyThreadS
   if(!state)
   {
     QString errMsg = QObject::tr("Invalid thread state for python interpreter.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return;
   }
 
@@ -262,20 +262,20 @@ void terrama2::services::analysis::core::python::runScriptGridAnalysis(PyThreadS
   catch(error_already_set)
   {
     std::string errMsg = extractException();
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg);
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg);
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
   }
 
   PyThreadState_Swap(previousState);
@@ -310,7 +310,7 @@ void terrama2::services::analysis::core::python::runScriptDCPAnalysis(PyThreadSt
   catch(error_already_set)
   {
     std::string errMsg = extractException();
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg);
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg);
   }
 }
 
@@ -344,18 +344,18 @@ void terrama2::services::analysis::core::python::addValue(const std::string& att
   }
   catch(const terrama2::Exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
     return;
   }
   catch(const std::exception& e)
   {
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, e.what());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, e.what());
     return;
   }
   catch(...)
   {
     QString errMsg = QObject::tr("An unknown exception occurred.");
-    context->addLogMessage(BaseContext::ERROR_MESSAGE, errMsg.toStdString());
+    context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, errMsg.toStdString());
     return;
   }
 

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -1,0 +1,3 @@
+{
+	"DataSeries": "DataSeries"
+}


### PR DESCRIPTION
- Changes in band identification for forecast operators,
- analysis log messages now have a type (error, warning...)
- Fix log messages call in forecast operators