### PR TITLE
Handling the Process logger errors in View Service

### DIFF
--- a/src/terrama2/core/utility/ProcessLogger.cpp
+++ b/src/terrama2/core/utility/ProcessLogger.cpp
@@ -65,6 +65,8 @@ terrama2::core::ProcessLogger::ProcessLogger(const ProcessLogger& other)
 
 void terrama2::core::ProcessLogger::setConnectionInfo(const te::core::URI& uri)
 {
+  isValid_ = false;
+
   try
   {
     closeConnection();
@@ -79,35 +81,33 @@ void terrama2::core::ProcessLogger::setConnectionInfo(const te::core::URI& uri)
       {
         QString errMsg = QObject::tr("Could not connect to database");
         TERRAMA2_LOG_ERROR() << errMsg;
-        isValid_ = false;
       }
-
-      isValid_ = true;
     }
     catch(std::exception& e)
     {
       QString errMsg = QObject::tr("Could not connect to database");
       TERRAMA2_LOG_ERROR() << errMsg << ": " << e.what();
-      isValid_ = false;
     }
   }
   catch(std::exception& e)
   {
     QString errMsg = QObject::tr("Could not connect to database");
     TERRAMA2_LOG_ERROR() << errMsg << ": " << e.what();
-    isValid_ = false;
   }
   catch(...)
   {
     // exception guard, slots should never emit exceptions.
     TERRAMA2_LOG_ERROR() << QObject::tr("Unknown exception...");
-    isValid_ = false;
   }
+
+  isValid_ = true;
 }
 
 
 void terrama2::core::ProcessLogger::setDataSource(te::da::DataSource* dataSource)
 {
+  isValid_ = false;
+
   dataSource_.reset(dataSource);
 
   try
@@ -116,13 +116,11 @@ void terrama2::core::ProcessLogger::setDataSource(te::da::DataSource* dataSource
 
     if(!dataSource_->isOpened())
     {
-      isValid_ = false;
       throw LogException();
     }
   }
   catch(std::exception& e)
   {
-    isValid_ = false;
     QString errMsg = QObject::tr("Could not connect to database");
     TERRAMA2_LOG_ERROR() << errMsg << ": " << e.what();
     throw LogException() << ErrorDescription(errMsg);

--- a/src/terrama2/core/utility/ProcessLogger.cpp
+++ b/src/terrama2/core/utility/ProcessLogger.cpp
@@ -53,6 +53,16 @@
 // STL
 #include <utility>
 
+terrama2::core::ProcessLogger::ProcessLogger(const ProcessLogger& other)
+{
+  schema_ = other.schema_;
+  tableName_ = other.tableName_;
+  messagesTableName_ = other.messagesTableName_;
+
+  setConnectionInfo(other.dataSource_->getConnectionInfo());
+}
+
+
 void terrama2::core::ProcessLogger::setConnectionInfo(const te::core::URI& uri)
 {
   try

--- a/src/terrama2/core/utility/ProcessLogger.cpp
+++ b/src/terrama2/core/utility/ProcessLogger.cpp
@@ -116,15 +116,19 @@ void terrama2::core::ProcessLogger::setDataSource(te::da::DataSource* dataSource
 
     if(!dataSource_->isOpened())
     {
+      isValid_ = false;
       throw LogException();
     }
   }
   catch(std::exception& e)
   {
+    isValid_ = false;
     QString errMsg = QObject::tr("Could not connect to database");
     TERRAMA2_LOG_ERROR() << errMsg << ": " << e.what();
     throw LogException() << ErrorDescription(errMsg);
   }
+
+  isValid_ = true;
 }
 
 void terrama2::core::ProcessLogger::closeConnection()

--- a/src/terrama2/core/utility/ProcessLogger.cpp
+++ b/src/terrama2/core/utility/ProcessLogger.cpp
@@ -82,6 +82,9 @@ void terrama2::core::ProcessLogger::setConnectionInfo(const te::core::URI& uri)
         QString errMsg = QObject::tr("Could not connect to database");
         TERRAMA2_LOG_ERROR() << errMsg;
       }
+
+      isValid_ = true;
+      return;
     }
     catch(std::exception& e)
     {
@@ -99,8 +102,6 @@ void terrama2::core::ProcessLogger::setConnectionInfo(const te::core::URI& uri)
     // exception guard, slots should never emit exceptions.
     TERRAMA2_LOG_ERROR() << QObject::tr("Unknown exception...");
   }
-
-  isValid_ = true;
 }
 
 

--- a/src/terrama2/core/utility/ProcessLogger.cpp
+++ b/src/terrama2/core/utility/ProcessLogger.cpp
@@ -79,29 +79,29 @@ void terrama2::core::ProcessLogger::setConnectionInfo(const te::core::URI& uri)
       {
         QString errMsg = QObject::tr("Could not connect to database");
         TERRAMA2_LOG_ERROR() << errMsg;
-        onError_ = true;
+        isValid_ = false;
       }
 
-      onError_ = false;
+      isValid_ = true;
     }
     catch(std::exception& e)
     {
       QString errMsg = QObject::tr("Could not connect to database");
       TERRAMA2_LOG_ERROR() << errMsg << ": " << e.what();
-      onError_ = true;
+      isValid_ = false;
     }
   }
   catch(std::exception& e)
   {
     QString errMsg = QObject::tr("Could not connect to database");
     TERRAMA2_LOG_ERROR() << errMsg << ": " << e.what();
-    onError_ = true;
+    isValid_ = false;
   }
   catch(...)
   {
     // exception guard, slots should never emit exceptions.
     TERRAMA2_LOG_ERROR() << QObject::tr("Unknown exception...");
-    onError_ = true;
+    isValid_ = false;
   }
 }
 
@@ -141,7 +141,7 @@ terrama2::core::ProcessLogger::~ProcessLogger()
 
 RegisterId terrama2::core::ProcessLogger::start(ProcessId processId) const
 {
-  if(onError_)
+  if(!isValid_)
     throw terrama2::core::LogException() << ErrorDescription("Error on log!");
 
   // send start to database
@@ -169,7 +169,7 @@ RegisterId terrama2::core::ProcessLogger::start(ProcessId processId) const
 
 void terrama2::core::ProcessLogger::addValue(const std::string& tag, const std::string& value, RegisterId registerId) const
 {
-  if(onError_)
+  if(!isValid_)
     throw terrama2::core::LogException() << ErrorDescription("Error on log!");
 
   if(tableName_.empty())
@@ -215,7 +215,7 @@ void terrama2::core::ProcessLogger::addValue(const std::string& tag, const std::
 void
 terrama2::core::ProcessLogger::log(MessageType messageType, const std::string &description, RegisterId registerId) const
 {
-  if(onError_)
+  if(!isValid_)
     throw terrama2::core::LogException() << ErrorDescription("Error on log!");
 
   if(tableName_.empty() || messagesTableName_.empty())
@@ -246,7 +246,7 @@ terrama2::core::ProcessLogger::log(MessageType messageType, const std::string &d
 void terrama2::core::ProcessLogger::result(Status status, const std::shared_ptr<te::dt::TimeInstantTZ> &dataTimestamp,
                                            RegisterId registerId) const
 {
-  if(onError_)
+  if(!isValid_)
     throw terrama2::core::LogException() << ErrorDescription("Error on log!");
 
   if(tableName_.empty())
@@ -283,7 +283,7 @@ void terrama2::core::ProcessLogger::result(Status status, const std::shared_ptr<
 
 std::shared_ptr< te::dt::TimeInstantTZ > terrama2::core::ProcessLogger::getLastProcessTimestamp(const ProcessId processId) const
 {
-  if(onError_)
+  if(!isValid_)
     throw terrama2::core::LogException() << ErrorDescription("Error on log!");
 
   if(tableName_.empty())
@@ -312,7 +312,7 @@ std::shared_ptr< te::dt::TimeInstantTZ > terrama2::core::ProcessLogger::getLastP
 
 std::shared_ptr< te::dt::TimeInstantTZ > terrama2::core::ProcessLogger::getDataLastTimestamp(const ProcessId processId) const
 {
-  if(onError_)
+  if(!isValid_)
     throw terrama2::core::LogException() << ErrorDescription("Error on log!");
 
   if(tableName_.empty())
@@ -341,7 +341,7 @@ std::shared_ptr< te::dt::TimeInstantTZ > terrama2::core::ProcessLogger::getDataL
 
 std::vector< terrama2::core::ProcessLogger::Log > terrama2::core::ProcessLogger::getLogs(const ProcessId processId, uint32_t begin, uint32_t end) const
 {
-  if(onError_)
+  if(!isValid_)
     throw terrama2::core::LogException() << ErrorDescription("Error on log!");
 
   if(tableName_.empty())
@@ -412,7 +412,7 @@ std::vector< terrama2::core::ProcessLogger::Log > terrama2::core::ProcessLogger:
 
 ProcessId terrama2::core::ProcessLogger::processID(const RegisterId registerId) const
 {
-  if(onError_)
+  if(!isValid_)
     throw terrama2::core::LogException() << ErrorDescription("Error on log!");
 
   if(tableName_.empty())
@@ -447,7 +447,7 @@ ProcessId terrama2::core::ProcessLogger::processID(const RegisterId registerId) 
 
 void terrama2::core::ProcessLogger::setTableName(std::string tableName)
 {
-  if(onError_)
+  if(!isValid_)
     throw terrama2::core::LogException() << ErrorDescription("Error on log!");
 
   // Check if schema_ exists in database
@@ -548,7 +548,7 @@ void terrama2::core::ProcessLogger::setTableName(std::string tableName)
 
 void terrama2::core::ProcessLogger::updateData(const ProcessId registerId, const QJsonObject obj) const
 {
-  if(onError_)
+  if(!isValid_)
     throw terrama2::core::LogException() << ErrorDescription("Error on log!");
 
   if(tableName_.empty())

--- a/src/terrama2/core/utility/ProcessLogger.cpp
+++ b/src/terrama2/core/utility/ProcessLogger.cpp
@@ -79,26 +79,32 @@ void terrama2::core::ProcessLogger::setConnectionInfo(const te::core::URI& uri)
       {
         QString errMsg = QObject::tr("Could not connect to database");
         TERRAMA2_LOG_ERROR() << errMsg;
+        onError_ = true;
       }
+
+      onError_ = false;
     }
     catch(std::exception& e)
     {
       QString errMsg = QObject::tr("Could not connect to database");
       TERRAMA2_LOG_ERROR() << errMsg << ": " << e.what();
+      onError_ = true;
     }
   }
   catch(std::exception& e)
   {
     QString errMsg = QObject::tr("Could not connect to database");
     TERRAMA2_LOG_ERROR() << errMsg << ": " << e.what();
+    onError_ = true;
   }
   catch(...)
   {
     // exception guard, slots should never emit exceptions.
     TERRAMA2_LOG_ERROR() << QObject::tr("Unknown exception...");
+    onError_ = true;
   }
-
 }
+
 
 void terrama2::core::ProcessLogger::setDataSource(te::da::DataSource* dataSource)
 {
@@ -135,8 +141,10 @@ terrama2::core::ProcessLogger::~ProcessLogger()
 
 RegisterId terrama2::core::ProcessLogger::start(ProcessId processId) const
 {
-  // send start to database
+  if(onError_)
+    throw terrama2::core::LogException() << ErrorDescription("Error on log!");
 
+  // send start to database
   if(tableName_.empty())
   {
     QString errMsg = QObject::tr("Can not find log table name");
@@ -161,6 +169,9 @@ RegisterId terrama2::core::ProcessLogger::start(ProcessId processId) const
 
 void terrama2::core::ProcessLogger::addValue(const std::string& tag, const std::string& value, RegisterId registerId) const
 {
+  if(onError_)
+    throw terrama2::core::LogException() << ErrorDescription("Error on log!");
+
   if(tableName_.empty())
   {
     QString errMsg = QObject::tr("Can not find log table name. Is it setted?");
@@ -204,6 +215,9 @@ void terrama2::core::ProcessLogger::addValue(const std::string& tag, const std::
 void
 terrama2::core::ProcessLogger::log(MessageType messageType, const std::string &description, RegisterId registerId) const
 {
+  if(onError_)
+    throw terrama2::core::LogException() << ErrorDescription("Error on log!");
+
   if(tableName_.empty() || messagesTableName_.empty())
   {
     QString errMsg = QObject::tr("Can not find log tables names.");
@@ -232,6 +246,9 @@ terrama2::core::ProcessLogger::log(MessageType messageType, const std::string &d
 void terrama2::core::ProcessLogger::result(Status status, const std::shared_ptr<te::dt::TimeInstantTZ> &dataTimestamp,
                                            RegisterId registerId) const
 {
+  if(onError_)
+    throw terrama2::core::LogException() << ErrorDescription("Error on log!");
+
   if(tableName_.empty())
   {
     QString errMsg = QObject::tr("Can not find log table name");
@@ -266,6 +283,9 @@ void terrama2::core::ProcessLogger::result(Status status, const std::shared_ptr<
 
 std::shared_ptr< te::dt::TimeInstantTZ > terrama2::core::ProcessLogger::getLastProcessTimestamp(const ProcessId processId) const
 {
+  if(onError_)
+    throw terrama2::core::LogException() << ErrorDescription("Error on log!");
+
   if(tableName_.empty())
   {
     QString errMsg = QObject::tr("Can not find log table name. Is it setted?");
@@ -292,6 +312,9 @@ std::shared_ptr< te::dt::TimeInstantTZ > terrama2::core::ProcessLogger::getLastP
 
 std::shared_ptr< te::dt::TimeInstantTZ > terrama2::core::ProcessLogger::getDataLastTimestamp(const ProcessId processId) const
 {
+  if(onError_)
+    throw terrama2::core::LogException() << ErrorDescription("Error on log!");
+
   if(tableName_.empty())
   {
     QString errMsg = QObject::tr("Can not find log table name. Is it setted?");
@@ -318,6 +341,9 @@ std::shared_ptr< te::dt::TimeInstantTZ > terrama2::core::ProcessLogger::getDataL
 
 std::vector< terrama2::core::ProcessLogger::Log > terrama2::core::ProcessLogger::getLogs(const ProcessId processId, uint32_t begin, uint32_t end) const
 {
+  if(onError_)
+    throw terrama2::core::LogException() << ErrorDescription("Error on log!");
+
   if(tableName_.empty())
   {
     QString errMsg = QObject::tr("Can not find log table name. Is it setted?");
@@ -386,6 +412,9 @@ std::vector< terrama2::core::ProcessLogger::Log > terrama2::core::ProcessLogger:
 
 ProcessId terrama2::core::ProcessLogger::processID(const RegisterId registerId) const
 {
+  if(onError_)
+    throw terrama2::core::LogException() << ErrorDescription("Error on log!");
+
   if(tableName_.empty())
   {
     QString errMsg = QObject::tr("Can not find log table name. Is it setted?");
@@ -418,6 +447,9 @@ ProcessId terrama2::core::ProcessLogger::processID(const RegisterId registerId) 
 
 void terrama2::core::ProcessLogger::setTableName(std::string tableName)
 {
+  if(onError_)
+    throw terrama2::core::LogException() << ErrorDescription("Error on log!");
+
   // Check if schema_ exists in database
   {
     std::shared_ptr<te::da::DataSourceTransactor> transactor = dataSource_->getTransactor();
@@ -516,6 +548,9 @@ void terrama2::core::ProcessLogger::setTableName(std::string tableName)
 
 void terrama2::core::ProcessLogger::updateData(const ProcessId registerId, const QJsonObject obj) const
 {
+  if(onError_)
+    throw terrama2::core::LogException() << ErrorDescription("Error on log!");
+
   if(tableName_.empty())
   {
     QString errMsg = QObject::tr("Can not find log table name. Is it setted?");

--- a/src/terrama2/core/utility/ProcessLogger.hpp
+++ b/src/terrama2/core/utility/ProcessLogger.hpp
@@ -209,7 +209,7 @@ namespace terrama2
         std::string tableName_ = "";
         std::string messagesTableName_ = "";
         std::unique_ptr< te::da::DataSource > dataSource_;
-        bool onError_ = false;
+        bool isValid_ = false;
 
     };
   }

--- a/src/terrama2/core/utility/ProcessLogger.hpp
+++ b/src/terrama2/core/utility/ProcessLogger.hpp
@@ -106,6 +106,7 @@ namespace terrama2
          */
         virtual ~ProcessLogger();
 
+
         /*!
          * \brief Log the start of the process.
          * \return The ID of table register
@@ -171,6 +172,11 @@ namespace terrama2
          * \brief Default constructor
          */
         ProcessLogger() = default;
+
+        /*!
+         * \brief Copy constructor
+         */
+        ProcessLogger(const ProcessLogger& other);
 
         /*!
          * \brief Set the process logger data source

--- a/src/terrama2/core/utility/ProcessLogger.hpp
+++ b/src/terrama2/core/utility/ProcessLogger.hpp
@@ -162,7 +162,7 @@ namespace terrama2
       public slots:
         /*!
         * \brief Reset connection to log database information
-        * \param connInfo Datasource connection information.
+        * \param uri Datasource connection information.
         */
         virtual void setConnectionInfo(const te::core::URI& uri);
 
@@ -203,12 +203,14 @@ namespace terrama2
          */
         void updateData(const RegisterId registerId, const QJsonObject obj) const;
 
+        void closeConnection();
+
         std::string schema_ = "terrama2";
         std::string tableName_ = "";
         std::string messagesTableName_ = "";
         std::unique_ptr< te::da::DataSource > dataSource_;
+        bool onError_ = false;
 
-        void closeConnection();
     };
   }
 }

--- a/src/terrama2/core/utility/Service.cpp
+++ b/src/terrama2/core/utility/Service.cpp
@@ -305,6 +305,10 @@ void terrama2::core::Service::addProcessToSchedule(ProcessPtr process) noexcept
         timers_.emplace(process->id, timer);
       }
     }
+    catch(const terrama2::core::LogException& e)
+    {
+      TERRAMA2_LOG_ERROR() << boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString();
+    }
     catch(const terrama2::core::InvalidFrequencyException&)
     {
       // invalid schedule, already logged

--- a/src/terrama2/services/view/core/MapsServer.hpp
+++ b/src/terrama2/services/view/core/MapsServer.hpp
@@ -64,7 +64,7 @@ namespace terrama2
             virtual QJsonObject generateLayers(const ViewPtr viewPtr,
                                                const std::unordered_map< terrama2::core::DataSeriesPtr, terrama2::core::DataProviderPtr >& dataSeriesProviders,
                                                const std::shared_ptr<DataManager> dataManager,
-                                               const std::shared_ptr< ViewLogger > logger,
+                                               const ViewLogger& logger,
                                                const RegisterId logId) = 0;
 
           protected:

--- a/src/terrama2/services/view/core/Service.cpp
+++ b/src/terrama2/services/view/core/Service.cpp
@@ -204,7 +204,7 @@ void terrama2::services::view::core::Service::viewJob(ViewId viewId,
   auto dataManager = weakDataManager.lock();
 
   // The logger is shared with the Maps Servers
-  std::shared_ptr< ViewLogger > jobLoggerPtr(new ViewLogger(logger));
+  std::shared_ptr< ViewLogger > jobLoggerPtr(&logger);
 
   if(!dataManager.get())
   {

--- a/src/terrama2/services/view/core/Service.cpp
+++ b/src/terrama2/services/view/core/Service.cpp
@@ -277,11 +277,6 @@ void terrama2::services::view::core::Service::viewJob(ViewId viewId,
     std::string errMsg = boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString();
     TERRAMA2_LOG_ERROR() << errMsg << std::endl;
     TERRAMA2_LOG_INFO() << QObject::tr("Build of view %1 finished with error(s).").arg(viewId);
-
-    sendProcessFinishedSignal(viewId, false);
-    notifyWaitQueue(viewId);
-
-    return;
   }
   catch(const terrama2::Exception& e)
   {

--- a/src/terrama2/services/view/core/Service.cpp
+++ b/src/terrama2/services/view/core/Service.cpp
@@ -272,6 +272,17 @@ void terrama2::services::view::core::Service::viewJob(ViewId viewId,
 
     return;
   }
+  catch(const terrama2::core::LogException& e)
+  {
+    std::string errMsg = boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString();
+    TERRAMA2_LOG_ERROR() << errMsg << std::endl;
+    TERRAMA2_LOG_INFO() << QObject::tr("Build of view %1 finished with error(s).").arg(viewId);
+
+    sendProcessFinishedSignal(viewId, false);
+    notifyWaitQueue(viewId);
+
+    return;
+  }
   catch(const terrama2::Exception& e)
   {
     std::string errMsg = boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString();

--- a/src/terrama2/services/view/core/Service.hpp
+++ b/src/terrama2/services/view/core/Service.hpp
@@ -109,7 +109,7 @@ namespace terrama2
           /*!
            * \brief viewJob
            * \param viewId
-           * \param logger A copy of the class logger, to avoid errors if it changes during the job
+           * \param logger A copy of a logger object, to avoid errors if it changes during the job
            * \param weakDataManager
            */
           void viewJob(ViewId viewId,

--- a/src/terrama2/services/view/core/Service.hpp
+++ b/src/terrama2/services/view/core/Service.hpp
@@ -106,8 +106,14 @@ namespace terrama2
           //! Connects signals from DataManager
           void connectDataManager();
 
+          /*!
+           * \brief viewJob
+           * \param viewId
+           * \param logger A copy of the class logger, to avoid errors if it changes during the job
+           * \param weakDataManager
+           */
           void viewJob(ViewId viewId,
-                       std::shared_ptr< ViewLogger > logger,
+                       ViewLogger logger,
                        std::weak_ptr<DataManager> weakDataManager);
 
           std::weak_ptr<DataManager> dataManager_; //!< Weak pointer to the DataManager

--- a/src/terrama2/services/view/core/ViewLogger.hpp
+++ b/src/terrama2/services/view/core/ViewLogger.hpp
@@ -42,13 +42,21 @@ namespace terrama2
       {
         class ViewLogger : public terrama2::core::ProcessLogger
         {
-        public:
+          public:
 
-          ViewLogger();
+            /*!
+             * \brief Default class Constructor
+             */
+            ViewLogger();
 
-          virtual ~ViewLogger() = default;
+            /*!
+             * \brief Copy constructor
+             */
+            ViewLogger(const ViewLogger&) = default;
 
-          virtual void setConnectionInfo(const te::core::URI& uri) override;
+            virtual ~ViewLogger() = default;
+
+            virtual void setConnectionInfo(const te::core::URI& uri) override;
         };
       }
     }

--- a/src/terrama2/services/view/core/data-access/Geoserver.cpp
+++ b/src/terrama2/services/view/core/data-access/Geoserver.cpp
@@ -762,7 +762,7 @@ void terrama2::services::view::core::GeoServer::getMapWMS(const std::string& sav
 QJsonObject terrama2::services::view::core::GeoServer::generateLayers(const ViewPtr viewPtr,
                                                                       const std::unordered_map< terrama2::core::DataSeriesPtr, terrama2::core::DataProviderPtr >& dataSeriesProviders,
                                                                       const std::shared_ptr<DataManager> dataManager,
-                                                                      const std::shared_ptr< ViewLogger > logger,
+                                                                      const  ViewLogger& logger,
                                                                       const RegisterId logId)
 {
   QJsonObject jsonAnswer;
@@ -916,7 +916,7 @@ QJsonObject terrama2::services::view::core::GeoServer::generateLayers(const View
 
             if(id == dataset->format.end() || foreing == dataset->format.end())
             {
-              logger->log(ViewLogger::ERROR_MESSAGE, "Data to join not informed.", logId);
+              logger.log(ViewLogger::ERROR_MESSAGE, "Data to join not informed.", logId);
               TERRAMA2_LOG_ERROR() << QObject::tr("Cannot join data from a different DB source!");
               continue;
             }
@@ -930,14 +930,14 @@ QJsonObject terrama2::services::view::core::GeoServer::generateLayers(const View
                || monitoredObjectUrl.port() != url.port()
                || monitoredObjectUrl.path().section("/", 1, 1) != url.path().section("/", 1, 1))
             {
-              logger->log(ViewLogger::ERROR_MESSAGE, "Data to join is in a different DB.", logId);
+              logger.log(ViewLogger::ERROR_MESSAGE, "Data to join is in a different DB.", logId);
               TERRAMA2_LOG_ERROR() << QObject::tr("Cannot join data from a different DB source!");
               continue;
             }
 
             if(monitoredObjectDataSeries->datasetList.empty())
             {
-              logger->log(ViewLogger::ERROR_MESSAGE, "No join data.", logId);
+              logger.log(ViewLogger::ERROR_MESSAGE, "No join data.", logId);
               TERRAMA2_LOG_ERROR() << QObject::tr("Cannot join data from a different DB source!");
               continue;
             }
@@ -976,7 +976,7 @@ QJsonObject terrama2::services::view::core::GeoServer::generateLayers(const View
     }
     else
     {
-      logger->log(ViewLogger::WARNING_MESSAGE, "No data to register.", logId);
+      logger.log(ViewLogger::WARNING_MESSAGE, "No data to register.", logId);
       TERRAMA2_LOG_WARNING() << QObject::tr("No data to register in maps server.");
       continue;
     }

--- a/src/terrama2/services/view/core/data-access/Geoserver.hpp
+++ b/src/terrama2/services/view/core/data-access/Geoserver.hpp
@@ -284,7 +284,7 @@ namespace terrama2
             virtual QJsonObject generateLayers(const ViewPtr viewPtr,
                                                const std::unordered_map< terrama2::core::DataSeriesPtr, terrama2::core::DataProviderPtr >& dataSeriesProviders,
                                                const std::shared_ptr<DataManager> dataManager,
-                                               const std::shared_ptr< ViewLogger > logger,
+                                               const ViewLogger& logger,
                                                const RegisterId logId);
 
 


### PR DESCRIPTION
- Using a copy of logger object to avoid changes during the service job;
- Checking  if the logger has a valid connection to data source, if not, don't execute any logger operation, stop the current job and don't add jobs to queue
- The service will remaining running with a invalid logger, but will not execute jobs until has a valid logger;

If approved, I will replicate this to the others services.
