### PR TITLE
Fix: continue when error opening file

### DIFF
--- a/src/terrama2/impl/DataAccessorFile.cpp
+++ b/src/terrama2/impl/DataAccessorFile.cpp
@@ -672,6 +672,8 @@ std::shared_ptr<te::dt::TimeInstantTZ> terrama2::core::DataAccessorFile::readFil
       continue;
 
     auto thisFileTimestamp = readFile(series, completeDataset, converter, fileInfo, mask, dataSet);
+    if(!thisFileTimestamp.get())
+      continue;
 
 
     //update lastest file timestamp


### PR DESCRIPTION
When Terralib can't open a file we get an empty timestamp, ignore and continue