### PR TITLE
Web monitor calendar and status icon fixes

### DIFF
--- a/webmonitor/public/javascripts/utils/calendar.js
+++ b/webmonitor/public/javascripts/utils/calendar.js
@@ -18,7 +18,7 @@ var makeHelperDatePicker = function(capability) {
   if (capability.extent instanceof Array) {
     datepicker += " data-min-date='" + capability.extent[0] + "' data-max-date='" + capability.extent[capability.extent.length - 1] + "'>";
   } else if (capability.extent instanceof Object) {
-    datepicker += " data-min-date='" + capability.extent.startDate + "' data-max-date='" + capability.extent.endDate + "'>";
+    datepicker += " data-min-date='" + capability.extent.startDate + "' data-max-date='" + capability.extent.endDate + "' start-date='' end-date=''" +">";
   }
 
   return datepicker;
@@ -51,11 +51,23 @@ $("#terrama2-layerexplorer").on("click", "#terrama2-calendar", function(event) {
   var hidden = $(self).find("input[type='hidden']");
   var minDate = $(hidden).attr('data-min-date');
   var maxDate = $(hidden).attr('data-max-date');
+  var startDate = $(hidden).attr('start-date');
+  var endDate = $(hidden).attr('end-date');
+
   if (!minDate || !maxDate) {
     return;
   }
   var mMinDate = moment(minDate);
   var mMaxDate = moment(maxDate);
+  var mStartDate;
+  var mEndDate;
+  if (!startDate || !endDate){
+    mStartDate = mMaxDate;
+    mEndDate = mMaxDate;
+  } else {
+    mStartDate = moment(startDate);
+    mEndDate = moment(endDate);
+  }
   if (calendar.length === 0) {
     calendar = $("<input type='text' id='" + capability + "' value='' style='display:none;'>");
     /**
@@ -65,8 +77,8 @@ $("#terrama2-layerexplorer").on("click", "#terrama2-calendar", function(event) {
     $(calendar).daterangepicker({
       "timePicker": true,
       "minDate": mMinDate,
-      "startDate": mMaxDate,
-      "endDate": mMaxDate,
+      "startDate": mStartDate,
+      "endDate": mEndDate,
       "maxDate": mMaxDate,
       "timePicker24Hour": true,
       "opens": "center"
@@ -84,6 +96,8 @@ $("#terrama2-layerexplorer").on("click", "#terrama2-calendar", function(event) {
       var timeFormat = "YYYY-MM-DDTHH:mm:ss";
       var pickerStartDate = picker.startDate.format(timeFormat);
       var pickerEndDate = picker.endDate.format(timeFormat);
+      $(hidden).attr('start-date', pickerStartDate);
+      $(hidden).attr('end-date', pickerEndDate);
 
       var layerTime = pickerStartDate + "Z/" + pickerEndDate + "Z";
       TerraMA2WebComponents.MapDisplay.updateLayerTime(/**id */layerId, /** time */layerTime);
@@ -93,8 +107,8 @@ $("#terrama2-layerexplorer").on("click", "#terrama2-calendar", function(event) {
     $(calendar).daterangepicker({
       "timePicker": true,
       "minDate": mMinDate,
-      "startDate": mMaxDate,
-      "endDate": mMaxDate,
+      "startDate": mStartDate,
+      "endDate": mEndDate,
       "maxDate": mMaxDate,
       "timePicker24Hour": true,
       "opens": "center"
@@ -106,6 +120,8 @@ $("#terrama2-layerexplorer").on("click", "#terrama2-calendar", function(event) {
       var timeFormat = "YYYY-MM-DDTHH:mm:ss";
       var pickerStartDate = picker.startDate.format(timeFormat);
       var pickerEndDate = picker.endDate.format(timeFormat);
+      $(hidden).attr('start-date', pickerStartDate);
+      $(hidden).attr('end-date', pickerEndDate);
 
       var layerTime = pickerStartDate + "Z/" + pickerEndDate + "Z";
       TerraMA2WebComponents.MapDisplay.updateLayerTime(/**id */layerId, /** time */layerTime);

--- a/webmonitor/views/index.html
+++ b/webmonitor/views/index.html
@@ -268,7 +268,7 @@
                 if (!inputElement.hasClass("disabled-content")){
                     inputElement.addClass("disabled-content");
                 }
-                changeLayerStatusIcon(data.requestId, "erraccess");
+                changeLayerStatusIcon(data.requestId.split('.').join('\\.'), "erraccess");
                 changeGroupStatusIcon(parent, "erraccess");
             } 
             // if connected enable the layer selection
@@ -280,7 +280,7 @@
                 var imageElement = listElement.find("#image-icon");
                 var lastStatus = imageElement.attr("src");
                 if (lastStatus == "{[ BASE_URL ]}images/status/gray_icon.svg"){
-                    changeLayerStatusIcon(data.requestId, "working");
+                    changeLayerStatusIcon(data.requestId.split('.').join('\\.'), "working");
                     changeGroupStatusIcon(parent, "working");
                 }
             }
@@ -597,7 +597,7 @@
         }
         var imageElement = $(this).closest('li').find("#image-icon");
         if (imageElement.attr("src") == "{[ BASE_URL ]}images/status/yellow-black.gif"){
-            changeLayerStatusIcon(layerid, "working");
+            changeLayerStatusIcon(layerid.split('.').join('\\.'), "working");
         }
 
     });


### PR DESCRIPTION
- [X] Fix layer status icon [1229](https://trac.dpi.inpe.br/terrama2/ticket/1229)
The "new" status didn't change to "working" status when click to see the layer
- [X] Fix calendar component [1233](https://trac.dpi.inpe.br/terrama2/ticket/1233)
The calendar component was not opened with the latest selected dates