### PR TITLE
Schedule option in Alert

### DIFF
--- a/webapp/core/DataManager.js
+++ b/webapp/core/DataManager.js
@@ -4290,7 +4290,7 @@ var DataManager = module.exports = {
       models.db.Alert.update(
         alertObject,
         Utils.extend({
-          fields: ["name", "description", "data_series_id", "active", "service_instance_id", "risk_id", "risk_attribute"],
+          fields: ["name", "description", "data_series_id", "active", "service_instance_id", "risk_id", "risk_attribute", "schedule_type", "schedule_id", "automatic_schedule_id"],
           where: restriction
         }, options))
         .then(function(){

--- a/webapp/core/data-model/Alert.js
+++ b/webapp/core/data-model/Alert.js
@@ -64,6 +64,18 @@ var Alert = function(params) {
    */
   this.data_series_id = params.data_series_id;
   /**
+   * Schedule type associated
+   * @name Alert#schedule_type
+   * @type {Schedule}
+   */
+  this.scheduleType = params.schedule_type;
+  /**
+   * Schedule associated
+   * @name Alert#schedule
+   * @type {Schedule}
+   */
+  this.schedule = params.schedule || {};
+  /**
    * @name Alert#automatic_schedule
    * @type {object}
    */
@@ -152,6 +164,8 @@ Alert.prototype.toObject = function() {
     description: this.description,
     data_series_id: this.data_series_id,
     risk_attribute: this.risk_attribute,
+    schedule_type: this.scheduleType,
+    schedule: this.schedule instanceof AbstractClass ? this.schedule.toObject() : {},
     automatic_schedule: this.automatic_schedule instanceof BaseClass ? this.automatic_schedule.toObject() : this.automatic_schedule,
     risk: this.risk instanceof BaseClass ? this.risk.toObject() : this.risk,
     additional_data: this.additional_data,
@@ -203,7 +217,8 @@ Alert.prototype.toService = function() {
     risk: this.risk instanceof BaseClass ? this.risk.toService() : this.risk,
     additional_data: additionalDataList,
     notifications: notificationList,
-    report_metadata: reportMetadataCopy
+    report_metadata: reportMetadataCopy,
+    schedule: this.schedule instanceof AbstractClass ? this.schedule.toObject() : {}
   });
 }
 

--- a/webapp/core/data-model/Alert.js
+++ b/webapp/core/data-model/Alert.js
@@ -165,7 +165,7 @@ Alert.prototype.toObject = function() {
     data_series_id: this.data_series_id,
     risk_attribute: this.risk_attribute,
     schedule_type: this.scheduleType,
-    schedule: this.schedule instanceof AbstractClass ? this.schedule.toObject() : {},
+    schedule: this.schedule instanceof BaseClass ? this.schedule.toObject() : {},
     automatic_schedule: this.automatic_schedule instanceof BaseClass ? this.automatic_schedule.toObject() : this.automatic_schedule,
     risk: this.risk instanceof BaseClass ? this.risk.toObject() : this.risk,
     additional_data: this.additional_data,
@@ -218,7 +218,7 @@ Alert.prototype.toService = function() {
     additional_data: additionalDataList,
     notifications: notificationList,
     report_metadata: reportMetadataCopy,
-    schedule: this.schedule instanceof AbstractClass ? this.schedule.toObject() : {}
+    schedule: this.schedule instanceof BaseClass ? this.schedule.toObject() : {}
   });
 }
 

--- a/webapp/core/facade/Alert.js
+++ b/webapp/core/facade/Alert.js
@@ -4,6 +4,8 @@
   var DataManager = require("./../DataManager");
   var TcpService = require("./../facade/tcp-manager/TcpService");
   var PromiseClass = require("./../Promise");
+  var Enums = require("./../Enums");
+  var Utils = require("./../Utils");
 
   /**
    * It represents a mock to handle alert.
@@ -156,8 +158,8 @@
           .then(function(alertResult){
             alert = alertResult;
 
-            if (alert.schedule_type == alertObject.schedule_type){
-              if (alert.schedule_type == Enums.ScheduleType.SCHEDULE){
+            if (alert.scheduleType == alertObject.schedule_type){
+              if (alert.scheduleType == Enums.ScheduleType.SCHEDULE){
                 // update
                 return DataManager.updateSchedule(alert.schedule.id, alertObject.schedule, options)
                   .then(function() {
@@ -166,9 +168,9 @@
                   });
               } else if (alert.scheduleType == Enums.ScheduleType.AUTOMATIC){
                 alertObject.automatic_schedule.data_ids = alertObject.schedule.data_ids;
-                return DataManager.updateAutomaticSchedule(alert.automaticSchedule.id, alertObject.automatic_schedule, options)
+                return DataManager.updateAutomaticSchedule(alert.automatic_schedule.id, alertObject.automatic_schedule, options)
                   .then(function(){
-                    alertObject.automatic_schedule_id = alert.automaticSchedule.id;
+                    alertObject.automatic_schedule_id = alert.automatic_schedule.id;
                     return null;
                   });
               }
@@ -205,7 +207,7 @@
                 }
               } else {
                 removeSchedule = true;
-                scheduleIdToRemove = alert.automaticSchedule.id;
+                scheduleIdToRemove = alert.automatic_schedule.id;
                 scheduleTypeToRemove = Enums.ScheduleType.AUTOMATIC;
                 alertObject.automatic_schedule_id = null;
                 if (alertObject.schedule_type == Enums.ScheduleType.SCHEDULE){

--- a/webapp/core/facade/Alert.js
+++ b/webapp/core/facade/Alert.js
@@ -58,12 +58,18 @@
 
         var promiser;
 
-        promiser = DataManager.addSchedule(alertObject.automatic_schedule, options);
+        if (Utils.isEmpty(alertObject.schedule))
+          promiser = PromiseClass.resolve();
+        else
+          promiser = DataManager.addSchedule(alertObject.schedule, options);
 
         return promiser
           .then(function(schedule) {
             if (schedule) {
-              alertObject.automatic_schedule_id = schedule.id;
+              if (alertObject.schedule_type == Enums.ScheduleType.AUTOMATIC)
+                alertObject.automatic_schedule_id = schedule.id;
+              else
+                alertObject.schedule_id = schedule.id;
             }
             var riskPromise;
             var riskObject = alertObject.risk;
@@ -142,9 +148,79 @@
       DataManager.orm.transaction(function(t){
         var options = {transaction: t};
         var oldAlertNotifications = [];
+        var alert;
+        var removeSchedule = null;
+        var scheduleIdToRemove = null;
+        var scheduleTypeToRemove = null;
         return DataManager.getAlert({id: alertId}, options)
           .then(function(alertResult){
-            oldAlertNotifications = alertResult.notifications;
+            alert = alertResult;
+
+            if (alert.schedule_type == alertObject.schedule_type){
+              if (alert.schedule_type == Enums.ScheduleType.SCHEDULE){
+                // update
+                return DataManager.updateSchedule(alert.schedule.id, alertObject.schedule, options)
+                  .then(function() {
+                    alertObject.schedule_id = alert.schedule.id;
+                    return null;
+                  });
+              } else if (alert.scheduleType == Enums.ScheduleType.AUTOMATIC){
+                alertObject.automatic_schedule.data_ids = alertObject.schedule.data_ids;
+                return DataManager.updateAutomaticSchedule(alert.automaticSchedule.id, alertObject.automatic_schedule, options)
+                  .then(function(){
+                    alertObject.automatic_schedule_id = alert.automaticSchedule.id;
+                    return null;
+                  });
+              }
+            } else {
+              // when change type of schedule
+              // if old schedule is MANUAL, create the new schedule
+              if (alert.scheduleType == Enums.ScheduleType.MANUAL){
+                return DataManager.addSchedule(alertObject.schedule, options)
+                  .then(function(scheduleResult){
+                    if (alertObject.schedule_type == Enums.ScheduleType.SCHEDULE){
+                      alert.schedule = scheduleResult;
+                      alertObject.schedule_id = scheduleResult.id;
+                      return null;
+                    } else {
+                      alert.automaticSchedule = scheduleResult;
+                      alertObject.automatic_schedule_id = scheduleResult.id;
+                      return null;
+                    }
+                  });
+              // if old schedule is SCHEDULE, delete schedule
+              } else if (alert.scheduleType == Enums.ScheduleType.SCHEDULE){
+                removeSchedule = true;
+                scheduleIdToRemove = alert.schedule.id;
+                scheduleTypeToRemove = Enums.ScheduleType.SCHEDULE;
+                alertObject.schedule_id = null;
+                // if new schedule is AUTOMATIC, create the schedule
+                if (alertObject.schedule_type == Enums.ScheduleType.AUTOMATIC){
+                  alertObject.schedule.id = null;
+                  return DataManager.addSchedule(alertObject.schedule, options)
+                    .then(function(scheduleResult){
+                      alert.automaticSchedule = scheduleResult;
+                      alertObject.automatic_schedule_id = scheduleResult.id;    
+                    });
+                }
+              } else {
+                removeSchedule = true;
+                scheduleIdToRemove = alert.automaticSchedule.id;
+                scheduleTypeToRemove = Enums.ScheduleType.AUTOMATIC;
+                alertObject.automatic_schedule_id = null;
+                if (alertObject.schedule_type == Enums.ScheduleType.SCHEDULE){
+                  alertObject.schedule.id = null;
+                  return DataManager.addSchedule(alertObject.schedule, options)
+                    .then(function(scheduleResult){
+                      alert.schedule = scheduleResult;
+                      alertObject.schedule_id = scheduleResult.id;    
+                    });
+                }
+              }
+            }
+          })
+          .then(function(){
+            oldAlertNotifications = alert.notifications;
             // Updating or adding a risk
             if (alertObject.risk.id){
               alertObject.risk_id = alertObject.risk.id;
@@ -185,7 +261,13 @@
             // updating alert
             return DataManager.updateAlert({id: alertId}, alertObject, options)
               .then(function(){
-                return DataManager.updateAutomaticSchedule(alertObject.automatic_schedule.id, alertObject.automatic_schedule, options)
+                if (removeSchedule) {
+                  if (scheduleTypeToRemove == Enums.ScheduleType.AUTOMATIC){
+                    return DataManager.removeAutomaticSchedule({id: scheduleIdToRemove}, options);
+                  } else {
+                    return DataManager.removeSchedule({id: scheduleIdToRemove}, options);
+                  }
+                }
               })
               .then(function(){
                 return DataManager.getAlert({id: alertId}, options);

--- a/webapp/models/Alert.js
+++ b/webapp/models/Alert.js
@@ -10,7 +10,11 @@ module.exports = function(sequelize, DataTypes) {
       active: DataTypes.BOOLEAN,
       name: DataTypes.STRING,
       description: DataTypes.TEXT,
-      risk_attribute: DataTypes.STRING
+      risk_attribute: DataTypes.STRING,
+      schedule_type: {
+        type: DataTypes.INTEGER,
+        allowNull: true
+      }
     },
     {
       underscored: true,
@@ -44,11 +48,20 @@ module.exports = function(sequelize, DataTypes) {
             }
           });
 
+          Alert.belongsTo(models.Schedule, {
+            onDelete: "CASCADE",
+            foreignKey: {
+              name: "schedule_id",
+              allowNull: true,
+              constraints: true
+            }
+          });
+
           Alert.belongsTo(models.AutomaticSchedule, {
             onDelete: "CASCADE",
             foreignKey: {
               name: 'automatic_schedule_id',
-              allowNull: false
+              allowNull: true
             }
           });
 

--- a/webapp/models/Schedule.js
+++ b/webapp/models/Schedule.js
@@ -48,6 +48,15 @@ module.exports = function(sequelize, DataTypes) {
               constraints: true
             }
           });
+
+          Schedule.hasOne(models.Alert, {
+            onDelete: "CASCADE",
+            foreignKey: {
+              name: 'schedule_id',
+              allowNull: true,
+              constraints: true
+            }
+          });
         }
       }
     }

--- a/webapp/public/javascripts/angular/alerts/controllers/index.js
+++ b/webapp/public/javascripts/angular/alerts/controllers/index.js
@@ -2,16 +2,20 @@ define([
   "TerraMA2WebApp/common/loader",
   "TerraMA2WebApp/common/app",
   "TerraMA2WebApp/alert-box/app",
+  "TerraMA2WebApp/data-series/schedule",
   "TerraMA2WebApp/data-series/services",
+  "TerraMA2WebApp/datetimepicker/directive",
   "TerraMA2WebApp/services/services",
   "TerraMA2WebApp/alerts/controllers/alert-list",
   "TerraMA2WebApp/alerts/controllers/alert-register-update"
-], function(moduleLoader, commonApp, messageBoxApp, dataSeriesServiceApp, serviceApp, ListController, RegisterUpdateController){
+], function(moduleLoader, commonApp, messageBoxApp, scheduleApp, dataSeriesServiceApp, datetimepicker, serviceApp, ListController, RegisterUpdateController){
   var moduleName = "terrama2.alerts.controllers";
 
   var deps = [messageBoxApp];
   moduleLoader("ui.select", deps);
   moduleLoader(dataSeriesServiceApp, deps);
+  moduleLoader(datetimepicker, deps);
+  moduleLoader(scheduleApp, deps);
   moduleLoader(serviceApp, deps);
 
   angular.module(moduleName, deps)

--- a/webapp/views/configuration/alert.html
+++ b/webapp/views/configuration/alert.html
@@ -6,17 +6,28 @@
 
 {% block styles %}
 
+<!-- Bootstrap Eonasdan datatimepicker (used in TerraMA² datetimepicker wrapper) -->
+<link rel="stylesheet" href="{[ BASE_URL ]}bower_components/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.css">
 <link rel="stylesheet" href="{[ BASE_URL ]}bower_components/angular-ui-select/dist/select.min.css" />
 
 {% endblock %}
 
 {% block javascripts %}
+<!-- Moment Datetime JS -->
+<script type="text/javascript" src="{[ BASE_URL ]}bower_components/moment/moment.js"></script>
+<!-- Bootstrap datetimepicker -->
+<script type="text/javascript" src="{[ BASE_URL ]}bower_components/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js"></script>
+
+<script type="text/javascript" src="{[ BASE_URL ]}bower_components/moment/locale/pt-br.js"></script>
+<script type="text/javascript" src="{[ BASE_URL ]}bower_components/moment/locale/es.js"></script>
+<script type="text/javascript" src="{[ BASE_URL ]}bower_components/moment/locale/fr.js"></script>
 
 <!-- Moment Datetime JS -->
 <script type="text/javascript" src="{[ BASE_URL ]}bower_components/moment/moment.js"></script>
 <script type="text/javascript" src="{[ BASE_URL ]}bower_components/moment/locale/pt-br.js"></script>
 <script type="text/javascript" src="{[ BASE_URL ]}bower_components/moment/locale/es.js"></script>
 <script type="text/javascript" src="{[ BASE_URL ]}bower_components/moment/locale/fr.js"></script>
+<script type="text/javascript" src="{[ BASE_URL ]}bower_components/angular-eonasdan-datetimepicker/dist/angular-eonasdan-datetimepicker.min.js"></script>
 <script src="{[ BASE_URL ]}bower_components/angular-ui-select/dist/select.min.js"></script>
 
 <script>
@@ -106,6 +117,12 @@
           </div>
         </div>
       </form>
+    </terrama2-box>
+    
+    <terrama2-box title="i18n.__('Schedule')" css="ctrl.css">
+      <div class="col-md-12">
+        <terrama2-schedule model="ctrl.alert.schedule" options="ctrl.scheduleOptions"></terrama2-schedule>
+      </div>
     </terrama2-box>
 
     <terrama2-box title="i18n.__('Data Series')" css="ctrl.css">


### PR DESCRIPTION
- [X] [1241](https://trac.dpi.inpe.br/terrama2/ticket/1241)
Options to select schedule type in Alert

Need update the database with the following script:
```
ALTER TABLE terrama2.alerts ADD COLUMN schedule_id INTEGER;
ALTER TABLE terrama2.alerts_schedule_id_fkey ADD CONSTRAINT alerts_schedule_id_fkey FOREIGN KEY (schedule_id) REFERENCES terrama2.schedules (id) MATCH SIMPLE ON UPDATE CASCADE ON DELETE CASCADE;
ALTER TABLE terrama2.alerts ADD COLUMN schedule_type INTEGER;

UPDATE terrama2.alerts SET schedule_type = 4;
```
