### PR TITLE
Continue analysis even with invalid geometries

### DIFF
--- a/src/terrama2/services/analysis/core/grid/zonal/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/Operator.cpp
@@ -136,6 +136,11 @@ double terrama2::services::analysis::core::grid::zonal::operatorImpl(terrama2::s
       QString errMsg(QObject::tr("Could not recover monitored object geometry."));
       throw InvalidDataSetException() << terrama2::ErrorDescription(errMsg);
     }
+
+    //if it's an invalid geometry, return nan but continue the analysis
+    if(!moGeom->isValid())
+      return std::nan("");
+      
     auto geomResult = createBuffer(buffer, moGeom);
 
     auto dataSeries = context->findDataSeries(dataSeriesName);

--- a/src/terrama2/services/analysis/core/grid/zonal/Utils.hpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/Utils.hpp
@@ -130,14 +130,20 @@ namespace terrama2
                   QString errMsg(QObject::tr("Could not recover monitored object geometry."));
                   throw InvalidDataSetException() << terrama2::ErrorDescription(errMsg);
                 }
+
+                std::unordered_map<std::pair<int, int>, std::pair<double, int>, boost::hash<std::pair<int, int> > > valuesMap;
+
+                //if it's an invalid geometry, return nan but continue the analysis
+                if(!moGeom->isValid())
+                  return valuesMap;
+
                 auto geomResult = createBuffer(buffer, moGeom);
 
                 auto dataSeries = context->findDataSeries(dataSeriesName);
 
                 /////////////////////////////////////////////////////////////////
                 //map of sum of values for each pixel
-                std::unordered_map<std::pair<int, int>, std::pair<double, int>, boost::hash<std::pair<int, int> > > valuesMap;
-
+                
                 terrama2::core::Filter filter;
                 filter.discardBefore = context->getTimeFromString(dateDiscardBefore);
                 filter.discardAfter = context->getTimeFromString(dateDiscardAfter);

--- a/src/terrama2/services/analysis/core/grid/zonal/forecast/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/forecast/Operator.cpp
@@ -129,6 +129,11 @@ double terrama2::services::analysis::core::grid::zonal::forecast::operatorImpl( 
       QString errMsg(QObject::tr("Could not recover monitored object geometry."));
       throw InvalidDataSetException() << terrama2::ErrorDescription(errMsg);
     }
+
+    //if it's an invalid geometry, return nan but continue the analysis
+    if(!moGeom->isValid())
+      return std::nan("");
+      
     auto geomResult = createBuffer(buffer, moGeom);
 
     auto dataSeries = context->findDataSeries(dataSeriesName);

--- a/src/terrama2/services/analysis/core/grid/zonal/forecast/accum/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/forecast/accum/Operator.cpp
@@ -134,6 +134,11 @@ double terrama2::services::analysis::core::grid::zonal::forecast::accum::operato
       QString errMsg(QObject::tr("Could not recover monitored object geometry."));
       throw InvalidDataSetException() << terrama2::ErrorDescription(errMsg);
     }
+
+    //if it's an invalid geometry, return nan but continue the analysis
+    if(!moGeom->isValid())
+      return std::nan("");
+      
     auto geomResult = createBuffer(buffer, moGeom);
 
     auto dataSeries = context->findDataSeries(dataSeriesName);

--- a/src/terrama2/services/analysis/core/grid/zonal/history/Operator.cpp
+++ b/src/terrama2/services/analysis/core/grid/zonal/history/Operator.cpp
@@ -104,6 +104,11 @@ int terrama2::services::analysis::core::grid::zonal::history::numImpl(const std:
       QString errMsg(QObject::tr("Could not recover monitored object geometry."));
       throw InvalidDataSetException() << terrama2::ErrorDescription(errMsg);
     }
+
+    //if it's an invalid geometry, return nan but continue the analysis
+    if(!moGeom->isValid())
+      return std::nan("");
+
     auto geomResult = createBuffer(buffer, moGeom);
 
     auto dataSeries = context->findDataSeries(dataSeriesName);
@@ -219,6 +224,10 @@ boost::python::list terrama2::services::analysis::core::grid::zonal::history::li
       QString errMsg(QObject::tr("Could not recover monitored object geometry."));
       throw InvalidDataSetException() << terrama2::ErrorDescription(errMsg);
     }
+
+    //if it's an invalid geometry, return nan but continue the analysis
+    if(!moGeom->isValid())
+      return {};
 
     auto geomResult = createBuffer(buffer, moGeom);
 

--- a/src/terrama2/services/analysis/core/occurrence/zonal/Operator.cpp
+++ b/src/terrama2/services/analysis/core/occurrence/zonal/Operator.cpp
@@ -131,6 +131,10 @@ double terrama2::services::analysis::core::occurrence::zonal::operatorImpl(terra
       throw InvalidDataSetException() << terrama2::ErrorDescription(errMsg);
     }
 
+    //if it's an invalid geometry, return nan but continue the analysis
+    if(!moGeom->isValid())
+      return std::nan("");
+
     //////////////////////////////////////////////////////////////////////////////////////
     // Save thread state and unlock python interpreter before entering multi-thread zone
     {


### PR DESCRIPTION
when using a monitored object with invalid geometries return nan but continue the analysis