### PR TITLE
View Service minor changes

### DIFF
--- a/src/terrama2/services/view/core/DataManager.cpp
+++ b/src/terrama2/services/view/core/DataManager.cpp
@@ -109,11 +109,12 @@ void terrama2::services::view::core::DataManager::removeView(ViewId viewId)
     throw terrama2::InvalidArgumentException() << ErrorDescription(errMsg);
   }
 
+  const DataSeriesId dataSeriesId = itPr->second->dataSeriesID;
   const std::string viewName = itPr->second->viewName;
 
   view_.erase(itPr);
 
-  emit viewRemoved(viewId, viewName);
+  emit viewRemoved(viewId, viewName, dataSeriesId);
 }
 
 void terrama2::services::view::core::DataManager::addJSon(const QJsonObject& obj)

--- a/src/terrama2/services/view/core/DataManager.cpp
+++ b/src/terrama2/services/view/core/DataManager.cpp
@@ -100,20 +100,20 @@ void terrama2::services::view::core::DataManager::update(terrama2::services::vie
 
 void terrama2::services::view::core::DataManager::removeView(ViewId viewId)
 {
+  std::lock_guard<std::recursive_mutex> lock(mtx_);
+  std::map<ViewId, ViewPtr>::const_iterator itPr = view_.find(viewId);
+  if(itPr == view_.end())
   {
-    std::lock_guard<std::recursive_mutex> lock(mtx_);
-    auto itPr = view_.find(viewId);
-    if(itPr == view_.end())
-    {
-      QString errMsg = QObject::tr("DataProvider not registered.");
-      TERRAMA2_LOG_ERROR() << errMsg;
-      throw terrama2::InvalidArgumentException() << ErrorDescription(errMsg);
-    }
-
-    view_.erase(itPr);
+    QString errMsg = QObject::tr("View not registered.");
+    TERRAMA2_LOG_ERROR() << errMsg;
+    throw terrama2::InvalidArgumentException() << ErrorDescription(errMsg);
   }
 
-  emit viewRemoved(viewId);
+  const std::string viewName = itPr->second->viewName;
+
+  view_.erase(itPr);
+
+  emit viewRemoved(viewId, viewName);
 }
 
 void terrama2::services::view::core::DataManager::addJSon(const QJsonObject& obj)

--- a/src/terrama2/services/view/core/DataManager.cpp
+++ b/src/terrama2/services/view/core/DataManager.cpp
@@ -100,19 +100,22 @@ void terrama2::services::view::core::DataManager::update(terrama2::services::vie
 
 void terrama2::services::view::core::DataManager::removeView(ViewId viewId)
 {
-  std::lock_guard<std::recursive_mutex> lock(mtx_);
-  std::map<ViewId, ViewPtr>::const_iterator itPr = view_.find(viewId);
-  if(itPr == view_.end())
+  DataSeriesId dataSeriesId;
+  std::string viewName;
+
   {
-    QString errMsg = QObject::tr("View not registered.");
-    TERRAMA2_LOG_ERROR() << errMsg;
-    throw terrama2::InvalidArgumentException() << ErrorDescription(errMsg);
+    std::lock_guard<std::recursive_mutex> lock(mtx_);
+    std::map<ViewId, ViewPtr>::const_iterator itPr = view_.find(viewId);
+    if(itPr == view_.end())
+    {
+      QString errMsg = QObject::tr("View not registered.");
+      TERRAMA2_LOG_ERROR() << errMsg;
+      throw terrama2::InvalidArgumentException() << ErrorDescription(errMsg);
+    }
+    dataSeriesId = itPr->second->dataSeriesID;
+    viewName = itPr->second->viewName;
+    view_.erase(itPr);
   }
-
-  const DataSeriesId dataSeriesId = itPr->second->dataSeriesID;
-  const std::string viewName = itPr->second->viewName;
-
-  view_.erase(itPr);
 
   emit viewRemoved(viewId, viewName, dataSeriesId);
 }

--- a/src/terrama2/services/view/core/DataManager.cpp
+++ b/src/terrama2/services/view/core/DataManager.cpp
@@ -104,7 +104,7 @@ void terrama2::services::view::core::DataManager::removeView(ViewId viewId)
 
   {
     std::lock_guard<std::recursive_mutex> lock(mtx_);
-    std::map<ViewId, ViewPtr>::const_iterator itPr = view_.find(viewId);
+    auto itPr = view_.find(viewId);
     if(itPr == view_.end())
     {
       QString errMsg = QObject::tr("View not registered.");

--- a/src/terrama2/services/view/core/DataManager.cpp
+++ b/src/terrama2/services/view/core/DataManager.cpp
@@ -101,7 +101,6 @@ void terrama2::services::view::core::DataManager::update(terrama2::services::vie
 void terrama2::services::view::core::DataManager::removeView(ViewId viewId)
 {
   DataSeriesId dataSeriesId;
-  std::string viewName;
 
   {
     std::lock_guard<std::recursive_mutex> lock(mtx_);
@@ -113,11 +112,10 @@ void terrama2::services::view::core::DataManager::removeView(ViewId viewId)
       throw terrama2::InvalidArgumentException() << ErrorDescription(errMsg);
     }
     dataSeriesId = itPr->second->dataSeriesID;
-    viewName = itPr->second->viewName;
     view_.erase(itPr);
   }
 
-  emit viewRemoved(viewId, viewName, dataSeriesId);
+  emit viewRemoved(viewId, dataSeriesId);
 }
 
 void terrama2::services::view::core::DataManager::addJSon(const QJsonObject& obj)

--- a/src/terrama2/services/view/core/DataManager.hpp
+++ b/src/terrama2/services/view/core/DataManager.hpp
@@ -149,7 +149,7 @@ namespace terrama2
           //! Signal to notify that a View has been updated.
           void viewUpdated(ViewPtr);
           //! Signal to notify that a View has been removed.
-          void viewRemoved(ViewId, std::string viewName);
+          void viewRemoved(ViewId, const std::string, DataSeriesId);
 
         protected:
           std::map<ViewId, ViewPtr> view_;//!< A view from ViewId to View.

--- a/src/terrama2/services/view/core/DataManager.hpp
+++ b/src/terrama2/services/view/core/DataManager.hpp
@@ -149,7 +149,7 @@ namespace terrama2
           //! Signal to notify that a View has been updated.
           void viewUpdated(ViewPtr);
           //! Signal to notify that a View has been removed.
-          void viewRemoved(ViewId, const std::string, DataSeriesId);
+          void viewRemoved(ViewId, DataSeriesId);
 
         protected:
           std::map<ViewId, ViewPtr> view_;//!< A view from ViewId to View.

--- a/src/terrama2/services/view/core/DataManager.hpp
+++ b/src/terrama2/services/view/core/DataManager.hpp
@@ -149,7 +149,7 @@ namespace terrama2
           //! Signal to notify that a View has been updated.
           void viewUpdated(ViewPtr);
           //! Signal to notify that a View has been removed.
-          void viewRemoved(ViewId);
+          void viewRemoved(ViewId, std::string viewName);
 
         protected:
           std::map<ViewId, ViewPtr> view_;//!< A view from ViewId to View.

--- a/src/terrama2/services/view/core/MapsServer.hpp
+++ b/src/terrama2/services/view/core/MapsServer.hpp
@@ -71,13 +71,13 @@ namespace terrama2
              *
              * Use this when you want to remove complete environment on MapsServer, such GeoServer
              *
-             * \note It may throw exception
+             * \note It may throw Exception
              *
-             * \param p Current View Id to remove
-             * \param recursive Flag for deep removing.
+             * \param id Current View Id to remove
+             * \param dataProvider Pointer to view data provider (optional)
+             * \param logger Logger to perform database cleanup. Useful to retrieve database connection arguments.
              */
             virtual void cleanup(const ViewId& id = 0,
-                                 const std::string& viewName = "",
                                  terrama2::core::DataProviderPtr dataProvider = nullptr,
                                  std::shared_ptr<terrama2::core::ProcessLogger> logger = nullptr) = 0;
 

--- a/src/terrama2/services/view/core/MapsServer.hpp
+++ b/src/terrama2/services/view/core/MapsServer.hpp
@@ -76,7 +76,10 @@ namespace terrama2
              * \param p Current View Id to remove
              * \param recursive Flag for deep removing.
              */
-            virtual void cleanup(const ViewId& v = 0) = 0;
+            virtual void cleanup(const ViewId& id = 0,
+                                 const std::string& viewName = "",
+                                 terrama2::core::DataProviderPtr dataProvider = nullptr,
+                                 std::shared_ptr<terrama2::core::ProcessLogger> logger = nullptr) = 0;
 
           protected:
 

--- a/src/terrama2/services/view/core/MapsServer.hpp
+++ b/src/terrama2/services/view/core/MapsServer.hpp
@@ -74,6 +74,7 @@ namespace terrama2
              * \note It may throw exception
              *
              * \param p Current View Id to remove
+             * \param recursive Flag for deep removing.
              */
             virtual void cleanup(const ViewId& v = 0) = 0;
 

--- a/src/terrama2/services/view/core/Service.cpp
+++ b/src/terrama2/services/view/core/Service.cpp
@@ -138,67 +138,84 @@ void terrama2::services::view::core::Service::connectDataManager()
           &terrama2::services::view::core::Service::updateView);
 }
 
-void terrama2::services::view::core::Service::removeView(ViewId viewId) noexcept
+void terrama2::services::view::core::Service::removeView(ViewId id, std::string viewName) noexcept
+{
+  removeCompleteView(id, viewName);
+}
+
+void terrama2::services::view::core::Service::removeCompleteView(const ViewId id, const std::string& viewName, bool removeAll) noexcept
 {
   try
   {
     std::lock_guard<std::mutex> lock(mutex_);
 
-    TERRAMA2_LOG_INFO() << tr("Trying to remove view %1.").arg(viewId);
+    TERRAMA2_LOG_INFO() << tr("Trying to remove view %1.").arg(id);
 
-    auto it = timers_.find(viewId);
+    auto it = timers_.find(id);
     if(it != timers_.end())
     {
-      auto timer = timers_.at(viewId);
+      auto timer = timers_.at(id);
       timer->disconnect();
-      timers_.erase(viewId);
+      timers_.erase(id);
     }
 
     // remove from queue
     processQueue_.erase(std::remove_if(processQueue_.begin(), processQueue_.end(),
-                                       [viewId](const terrama2::core::ExecutionPackage& executionPackage)
-                                       { return viewId == executionPackage.processId; }), processQueue_.end());
+                                       [&id](const terrama2::core::ExecutionPackage& executionPackage)
+                                       { return id == executionPackage.processId; }), processQueue_.end());
 
-    // removing from geoserver
-    try
+    if (removeAll)
     {
+      // Retrieving Maps server handler
       MapsServerPtr mapsServer = MapsServerFactory::getInstance().make(mapsServerUri_, "GEOSERVER");
-      mapsServer->cleanup(viewId);
-    }
-    catch(const terrama2::services::view::core::NotFoundGeoserverException& e)
-    {
-      // Nothing
-      TERRAMA2_LOG_DEBUG() << tr("There is no workspace in GeoServer");
-    }
-    catch(const terrama2::services::view::core::ViewGeoserverException&)
-    {
-      TERRAMA2_LOG_WARNING() << tr("Could not remove GeoServer workspace. Please remove it manually");
+      try
+      {
+        // removing from geoserver
+        mapsServer->cleanup(id);
+      }
+      catch(const terrama2::services::view::core::NotFoundGeoserverException& e)
+      {
+        // Nothing
+        TERRAMA2_LOG_DEBUG() << tr("There is no workspace in GeoServer");
+      }
+      catch(const terrama2::services::view::core::ViewGeoserverException&)
+      {
+        // TODO: Improve validation in order to notify WebApp
+        TERRAMA2_LOG_WARNING() << tr("Could not remove GeoServer workspace. Please remove it manually");
+      }
+
+      // TODO: move it to specific method
+      const std::string& tableName = viewName + std::to_string(id);
+      // Removing view table
+      removeTable(tableName, logger_->getConnectionInfo());
+      // Remove files
+
     }
 
-    waitQueue_.erase(viewId);
+    waitQueue_.erase(id);
 
-    TERRAMA2_LOG_INFO() << tr("View %1 removed successfully.").arg(viewId);
+    TERRAMA2_LOG_INFO() << tr("View %1 removed successfully.").arg(id);
   }
   catch(const boost::exception& e)
   {
     TERRAMA2_LOG_ERROR() << boost::get_error_info<terrama2::ErrorDescription>(e);
-    TERRAMA2_LOG_INFO() << tr("Could not remove view: %1.").arg(viewId);
+    TERRAMA2_LOG_INFO() << tr("Could not remove view: %1.").arg(id);
   }
   catch(const std::exception& e)
   {
     TERRAMA2_LOG_ERROR() << e.what();
-    TERRAMA2_LOG_INFO() << tr("Could not remove view: %1.").arg(viewId);
+    TERRAMA2_LOG_INFO() << tr("Could not remove view: %1.").arg(id);
   }
   catch(...)
   {
     TERRAMA2_LOG_ERROR() << tr("Unknown error");
-    TERRAMA2_LOG_INFO() << tr("Could not remove view: %1.").arg(viewId);
+    TERRAMA2_LOG_INFO() << tr("Could not remove view: %1.").arg(id);
   }
 }
 
 void terrama2::services::view::core::Service::updateView(ViewPtr view) noexcept
 {
-  removeView(view->id);
+  removeCompleteView(view->id, view->viewName, false);
   addProcessToSchedule(view);
 }
 
@@ -352,11 +369,7 @@ void terrama2::services::view::core::Service::viewJob(const terrama2::core::Exec
 void terrama2::services::view::core::Service::updateAdditionalInfo(const QJsonObject& obj) noexcept
 {
   if(!obj.contains("maps_server"))
-  {
     TERRAMA2_LOG_ERROR() << tr("Missing the Maps Server URI in service additional info!");
-  }
   else
-  {
     mapsServerUri_ = te::core::URI(obj["maps_server"].toString().toStdString());
-  }
 }

--- a/src/terrama2/services/view/core/Service.cpp
+++ b/src/terrama2/services/view/core/Service.cpp
@@ -138,12 +138,12 @@ void terrama2::services::view::core::Service::connectDataManager()
           &terrama2::services::view::core::Service::updateView);
 }
 
-void terrama2::services::view::core::Service::removeView(ViewId id, const std::string viewName, DataSeriesId dataSeriesId) noexcept
+void terrama2::services::view::core::Service::removeView(ViewId id, DataSeriesId dataSeriesId) noexcept
 {
-  removeCompleteView(id, viewName, dataSeriesId);
+  removeCompleteView(id, dataSeriesId);
 }
 
-void terrama2::services::view::core::Service::removeCompleteView(ViewId id, const std::string viewName, DataSeriesId dataSeriesId, bool removeAll) noexcept
+void terrama2::services::view::core::Service::removeCompleteView(ViewId id, DataSeriesId dataSeriesId, bool removeAll) noexcept
 {
   try
   {
@@ -184,7 +184,7 @@ void terrama2::services::view::core::Service::removeCompleteView(ViewId id, cons
       try
       {
         // removing from geoserver
-        mapsServer->cleanup(id, viewName, inputDataProvider, logger_);
+        mapsServer->cleanup(id, inputDataProvider, logger_);
       }
       catch(const terrama2::services::view::core::NotFoundGeoserverException& e)
       {
@@ -194,7 +194,7 @@ void terrama2::services::view::core::Service::removeCompleteView(ViewId id, cons
       catch(const terrama2::services::view::core::ViewGeoserverException&)
       {
         // TODO: Improve validation in order to notify WebApp
-        TERRAMA2_LOG_WARNING() << tr("Could not remove GeoServer workspace. Please remove it manually");
+        TERRAMA2_LOG_WARNING() << tr("Could not perform clean up in GeoServer and database. Please remove it manually");
       }
     }
 
@@ -221,7 +221,7 @@ void terrama2::services::view::core::Service::removeCompleteView(ViewId id, cons
 
 void terrama2::services::view::core::Service::updateView(ViewPtr view) noexcept
 {
-  removeCompleteView(view->id, view->viewName, view->dataSeriesID, false);
+  removeCompleteView(view->id, view->dataSeriesID, false);
   addProcessToSchedule(view);
 }
 

--- a/src/terrama2/services/view/core/Service.cpp
+++ b/src/terrama2/services/view/core/Service.cpp
@@ -178,10 +178,10 @@ void terrama2::services::view::core::Service::removeCompleteView(ViewId id, Data
         lock.unlock();
       }
 
-      // Retrieving Maps server handler
-      MapsServerPtr mapsServer = MapsServerFactory::getInstance().make(mapsServerUri_, "GEOSERVER");
       try
       {
+        // Retrieving Maps server handler
+        MapsServerPtr mapsServer = MapsServerFactory::getInstance().make(mapsServerUri_, "GEOSERVER");
         // removing from geoserver
         mapsServer->cleanup(id, inputDataProvider, logger_);
       }

--- a/src/terrama2/services/view/core/Service.cpp
+++ b/src/terrama2/services/view/core/Service.cpp
@@ -166,14 +166,13 @@ void terrama2::services::view::core::Service::removeCompleteView(ViewId id, Data
 
     if (removeAll)
     {
-      terrama2::core::DataSeriesPtr inputDataSeries;
       terrama2::core::DataProviderPtr inputDataProvider;
 
       // Locking datamanager
       {
         auto dataManager = dataManager_.lock();
         auto lock = dataManager->getLock();
-        inputDataSeries = dataManager->findDataSeries(dataSeriesId);
+        terrama2::core::DataSeriesPtr inputDataSeries = dataManager->findDataSeries(dataSeriesId);
         inputDataProvider = dataManager->findDataProvider(inputDataSeries->dataProviderId);
 
         lock.unlock();

--- a/src/terrama2/services/view/core/Service.hpp
+++ b/src/terrama2/services/view/core/Service.hpp
@@ -91,7 +91,7 @@ namespace terrama2
           /*!
            * \brief Removes View from memory and tries to remove entire workspace of GeoServer
            * \param viewId View identifier
-           * \param removeAll Flag to remove everything. It includes both geoserver workspace as table metadata. Default "false"
+           * \param removeAll Flag to remove everything. It includes both geoserver workspace as table metadata. Default "true"
            */
           void removeCompleteView(ViewId id, DataSeriesId dataSeriesId, bool removeAll = true) noexcept;
 

--- a/src/terrama2/services/view/core/Service.hpp
+++ b/src/terrama2/services/view/core/Service.hpp
@@ -79,7 +79,7 @@ namespace terrama2
 
             Rennuning processes will continue until finished.
           */
-          void removeView(ViewId id, std::string viewName) noexcept;
+          void removeView(ViewId id, const std::string viewName, DataSeriesId dataSeriesId) noexcept;
 
           /*!
            * \brief Receive a jSon and update service information with it
@@ -93,7 +93,7 @@ namespace terrama2
            * \param viewId View identifier
            * \param removeAll Flag to remove everything. It includes both geoserver workspace as table metadata. Default "false"
            */
-          void removeCompleteView(const ViewId id, const std::string& viewName, bool removeAll = true) noexcept;
+          void removeCompleteView(ViewId id, const std::string viewName, DataSeriesId dataSeriesId, bool removeAll = true) noexcept;
 
         protected:
 

--- a/src/terrama2/services/view/core/Service.hpp
+++ b/src/terrama2/services/view/core/Service.hpp
@@ -77,9 +77,9 @@ namespace terrama2
           /*!
             \brief Removes the View.
 
-            Rennuning processes will continue until finished.
+            Running processes will continue until finished.
           */
-          void removeView(ViewId id, const std::string viewName, DataSeriesId dataSeriesId) noexcept;
+          void removeView(ViewId id, DataSeriesId dataSeriesId) noexcept;
 
           /*!
            * \brief Receive a jSon and update service information with it
@@ -93,7 +93,7 @@ namespace terrama2
            * \param viewId View identifier
            * \param removeAll Flag to remove everything. It includes both geoserver workspace as table metadata. Default "false"
            */
-          void removeCompleteView(ViewId id, const std::string viewName, DataSeriesId dataSeriesId, bool removeAll = true) noexcept;
+          void removeCompleteView(ViewId id, DataSeriesId dataSeriesId, bool removeAll = true) noexcept;
 
         protected:
 

--- a/src/terrama2/services/view/core/Service.hpp
+++ b/src/terrama2/services/view/core/Service.hpp
@@ -79,13 +79,21 @@ namespace terrama2
 
             Rennuning processes will continue until finished.
           */
-          void removeView(ViewId viewId) noexcept;
+          void removeView(ViewId id, std::string viewName) noexcept;
 
           /*!
            * \brief Receive a jSon and update service information with it
            * \param obj jSon with additional information for service
            */
           virtual void updateAdditionalInfo(const QJsonObject& obj) noexcept override;
+
+        private:
+          /*!
+           * \brief Removes View from memory and tries to remove entire workspace of GeoServer
+           * \param viewId View identifier
+           * \param removeAll Flag to remove everything. It includes both geoserver workspace as table metadata. Default "false"
+           */
+          void removeCompleteView(const ViewId id, const std::string& viewName, bool removeAll = true) noexcept;
 
         protected:
 

--- a/src/terrama2/services/view/core/Utils.cpp
+++ b/src/terrama2/services/view/core/Utils.cpp
@@ -63,6 +63,7 @@
 
 // QT
 #include <QFile>
+#include <QFileInfo>
 
 void terrama2::services::view::core::registerFactories()
 {
@@ -226,13 +227,25 @@ void terrama2::services::view::core::removeTable(const std::string& name, const 
 
 void terrama2::services::view::core::removeFile(const std::string& filepath)
 {
-  QFile file(filepath.c_str());
+  QFileInfo file(filepath.c_str());
 
   if (file.exists())
-    if (!file.remove())
+  {
+    if (file.isFile())
     {
-      QString errMsg = QObject::tr("Could not remove file: %1").arg(filepath.c_str());
+      QFile f(file.filePath());
+      if (!f.remove())
+      {
+        QString errMsg = QObject::tr("Could not remove file: %1").arg(filepath.c_str());
+        TERRAMA2_LOG_ERROR() << errMsg;
+        throw Exception() << ErrorDescription(errMsg);
+      }
+    }
+    else
+    {
+      const QString errMsg = QObject::tr("Not a file: %1").arg(filepath.c_str());
       TERRAMA2_LOG_ERROR() << errMsg;
       throw Exception() << ErrorDescription(errMsg);
     }
+  }
 }

--- a/src/terrama2/services/view/core/Utils.cpp
+++ b/src/terrama2/services/view/core/Utils.cpp
@@ -43,6 +43,11 @@
 #include "../../../core/utility/TimeUtils.hpp"
 #include "../../../core/utility/Utils.hpp"
 
+// TerraLib Datasource
+#include <terralib/dataaccess/datasource/DataSource.h>
+#include <terralib/dataaccess/datasource/DataSourceFactory.h>
+#include <terralib/dataaccess/datasource/DataSourceTransactor.h>
+
 // TerraLib
 #include <terralib/se/Categorize.h>
 #include <terralib/se/RasterSymbolizer.h>
@@ -204,4 +209,22 @@ std::string terrama2::services::view::core::toString(const double value, const i
   ss << std::fixed << std::setprecision(precision) << value;
 
   return ss.str();
+}
+
+void terrama2::services::view::core::removeTable(const std::string& name, const te::core::URI& uri)
+{
+  std::shared_ptr<te::da::DataSource> dataSource = te::da::DataSourceFactory::make("POSTGIS", uri);
+
+  try
+  {
+    dataSource->open();
+    dataSource->dropDataSet(name);
+  }
+  catch(...)
+  {
+    // Nothing.
+  }
+
+  if (dataSource->isOpened())
+    dataSource->close();
 }

--- a/src/terrama2/services/view/core/Utils.cpp
+++ b/src/terrama2/services/view/core/Utils.cpp
@@ -226,31 +226,6 @@ void terrama2::services::view::core::removeTable(const std::string& name, const 
     dataSource->close();
 }
 
-void terrama2::services::view::core::removeFile(const std::string& filepath)
-{
-  QFileInfo file(filepath.c_str());
-
-  if (file.exists())
-  {
-    if (file.isFile())
-    {
-      QFile f(file.filePath());
-      if (!f.remove())
-      {
-        QString errMsg = QObject::tr("Could not remove file: %1").arg(filepath.c_str());
-        TERRAMA2_LOG_ERROR() << errMsg;
-        throw Exception() << ErrorDescription(errMsg);
-      }
-    }
-    else
-    {
-      const QString errMsg = QObject::tr("Not a file: %1").arg(filepath.c_str());
-      TERRAMA2_LOG_ERROR() << errMsg;
-      throw Exception() << ErrorDescription(errMsg);
-    }
-  }
-}
-
 void terrama2::services::view::core::createFolder(const std::string& folderpath)
 {
   QDir directory(folderpath.c_str());

--- a/src/terrama2/services/view/core/Utils.cpp
+++ b/src/terrama2/services/view/core/Utils.cpp
@@ -64,6 +64,7 @@
 // QT
 #include <QFile>
 #include <QFileInfo>
+#include <QDir>
 
 void terrama2::services::view::core::registerFactories()
 {
@@ -248,4 +249,36 @@ void terrama2::services::view::core::removeFile(const std::string& filepath)
       throw Exception() << ErrorDescription(errMsg);
     }
   }
+}
+
+void terrama2::services::view::core::createFolder(const std::string& folderpath)
+{
+  QDir directory(folderpath.c_str());
+
+  if (!directory.exists())
+    if (!directory.mkdir(directory.path()))
+    {
+      const QString errMsg = QObject::tr("Could not create directory %1").arg(directory.path());
+      TERRAMA2_LOG_ERROR() << errMsg;
+      throw Exception() << ErrorDescription(errMsg);
+    }
+}
+
+void terrama2::services::view::core::removeFolder(const std::string& folderpath)
+{
+  QDir directory(folderpath.c_str());
+
+  if (directory.exists())
+    if (!directory.removeRecursively())
+    {
+      const QString errMsg = QObject::tr("Could not remove directory %1").arg(directory.path());
+      TERRAMA2_LOG_ERROR() << errMsg;
+      throw Exception() << ErrorDescription(errMsg);
+    }
+}
+
+void terrama2::services::view::core::recreateFolder(const std::string& folderpath)
+{
+  removeFolder(folderpath);
+  createFolder(folderpath);
 }

--- a/src/terrama2/services/view/core/Utils.cpp
+++ b/src/terrama2/services/view/core/Utils.cpp
@@ -61,6 +61,8 @@
 #include <sstream>
 #include <iomanip>
 
+// QT
+#include <QFile>
 
 void terrama2::services::view::core::registerFactories()
 {
@@ -215,16 +217,22 @@ void terrama2::services::view::core::removeTable(const std::string& name, const 
 {
   std::shared_ptr<te::da::DataSource> dataSource = te::da::DataSourceFactory::make("POSTGIS", uri);
 
-  try
-  {
-    dataSource->open();
-    dataSource->dropDataSet(name);
-  }
-  catch(...)
-  {
-    // Nothing.
-  }
+  dataSource->open();
+  dataSource->dropDataSet(name);
 
   if (dataSource->isOpened())
     dataSource->close();
+}
+
+void terrama2::services::view::core::removeFile(const std::string& filepath)
+{
+  QFile file(filepath.c_str());
+
+  if (file.exists())
+    if (!file.remove())
+    {
+      QString errMsg = QObject::tr("Could not remove file: %1").arg(filepath.c_str());
+      TERRAMA2_LOG_ERROR() << errMsg;
+      throw Exception() << ErrorDescription(errMsg);
+    }
 }

--- a/src/terrama2/services/view/core/Utils.hpp
+++ b/src/terrama2/services/view/core/Utils.hpp
@@ -38,6 +38,7 @@
 
 // TerraLib
 #include <terralib/se/Symbolizer.h>
+#include <terralib/core/uri.h>
 
 // STD
 #include <memory>
@@ -75,6 +76,8 @@ namespace terrama2
          * \return String value
          */
         std::string toString(const double value, const int& precision = 8);
+
+        void removeTable(const std::string& name, const te::core::URI& uri);
 
       } // end namespace core
     }   // end namespace view

--- a/src/terrama2/services/view/core/Utils.hpp
+++ b/src/terrama2/services/view/core/Utils.hpp
@@ -87,13 +87,36 @@ namespace terrama2
         /*!
          * \brief Tries to remove file from disk
          *
-         * \note It does not throw exception if files does not exist.
+         * \note It only throw exception when the filepath exists but could not remove (Permission management/Lock)
          *
          * \throws Exception when could not remove file.
          *
          * \param filepath Path to file
          */
         void removeFile(const std::string& filepath);
+
+        /*!
+         * \brief Tries to remove folder
+         *
+         * \throws Exception when could not remove folder
+         *
+         * \param folderpath Path to create
+         */
+        void removeFolder(const std::string& folderpath);
+
+        /*!
+         * \brief Tries to create folder
+         * \param folderpath Path to create
+         */
+        void createFolder(const std::string& folderpath);
+
+        /*!
+         * \brief Tries to remove and then create folder
+         * \throws Exception when could not remove folder
+         *
+         * \param folderpath Path to re-criate
+         */
+        void recreateFolder(const std::string& folderpath);
 
       } // end namespace core
     }   // end namespace view

--- a/src/terrama2/services/view/core/Utils.hpp
+++ b/src/terrama2/services/view/core/Utils.hpp
@@ -77,7 +77,23 @@ namespace terrama2
          */
         std::string toString(const double value, const int& precision = 8);
 
+        /*!
+         * \brief Removes table from provided URI.
+         * \param name Table name
+         * \param uri Connection URI
+         */
         void removeTable(const std::string& name, const te::core::URI& uri);
+
+        /*!
+         * \brief Tries to remove file from disk
+         *
+         * \note It does not throw exception if files does not exist.
+         *
+         * \throws Exception when could not remove file.
+         *
+         * \param filepath Path to file
+         */
+        void removeFile(const std::string& filepath);
 
       } // end namespace core
     }   // end namespace view

--- a/src/terrama2/services/view/core/Utils.hpp
+++ b/src/terrama2/services/view/core/Utils.hpp
@@ -85,17 +85,6 @@ namespace terrama2
         void removeTable(const std::string& name, const te::core::URI& uri);
 
         /*!
-         * \brief Tries to remove file from disk
-         *
-         * \note It only throw exception when the filepath exists but could not remove (Permission management/Lock)
-         *
-         * \throws Exception when could not remove file.
-         *
-         * \param filepath Path to file
-         */
-        void removeFile(const std::string& filepath);
-
-        /*!
          * \brief Tries to remove folder
          *
          * \throws Exception when could not remove folder
@@ -111,8 +100,8 @@ namespace terrama2
         void createFolder(const std::string& folderpath);
 
         /*!
-         * \brief Tries to remove and then create folder
-         * \throws Exception when could not remove folder
+         * \brief Tries to remove and then create new folder
+         * \throws Exception when could not create or remove folder
          *
          * \param folderpath Path to re-criate
          */

--- a/src/terrama2/services/view/core/View.hpp
+++ b/src/terrama2/services/view/core/View.hpp
@@ -153,6 +153,35 @@ namespace terrama2
                 std::vector< Rule > rules;
             };
 
+          View() = default;
+          View(View&& v)
+            : viewName(v.viewName),
+              dataSeriesID(v.dataSeriesID),
+              legend(std::move(v.legend)),
+              imageName(v.imageName),
+              imageType(v.imageType),
+              imageResolutionWidth(v.imageResolutionWidth),
+              imageResolutionHeight(v.imageResolutionHeight),
+              srid(v.srid)
+          {
+          }
+
+          View& operator=(View&& v)
+          {
+            if (this != &v)
+            {
+              viewName = v.viewName;
+              dataSeriesID = v.dataSeriesID;
+              legend = std::move(v.legend);
+              imageName = v.imageName;
+              imageType = v.imageType;
+              imageResolutionWidth = v.imageResolutionWidth;
+              imageResolutionHeight = v.imageResolutionHeight;
+              srid = v.srid;
+            }
+            return *this;
+          }
+
           std::string viewName = "";
 
           DataSeriesId dataSeriesID; //!< DataSeries ID that compose this view

--- a/src/terrama2/services/view/core/View.hpp
+++ b/src/terrama2/services/view/core/View.hpp
@@ -153,35 +153,6 @@ namespace terrama2
                 std::vector< Rule > rules;
             };
 
-          View() = default;
-          View(View&& v)
-            : viewName(v.viewName),
-              dataSeriesID(v.dataSeriesID),
-              legend(std::move(v.legend)),
-              imageName(v.imageName),
-              imageType(v.imageType),
-              imageResolutionWidth(v.imageResolutionWidth),
-              imageResolutionHeight(v.imageResolutionHeight),
-              srid(v.srid)
-          {
-          }
-
-          View& operator=(View&& v)
-          {
-            if (this != &v)
-            {
-              viewName = v.viewName;
-              dataSeriesID = v.dataSeriesID;
-              legend = std::move(v.legend);
-              imageName = v.imageName;
-              imageType = v.imageType;
-              imageResolutionWidth = v.imageResolutionWidth;
-              imageResolutionHeight = v.imageResolutionHeight;
-              srid = v.srid;
-            }
-            return *this;
-          }
-
           std::string viewName = "";
 
           DataSeriesId dataSeriesID; //!< DataSeries ID that compose this view

--- a/src/terrama2/services/view/core/data-access/Geoserver.cpp
+++ b/src/terrama2/services/view/core/data-access/Geoserver.cpp
@@ -236,7 +236,7 @@ QJsonObject terrama2::services::view::core::GeoServer::generateLayers(const View
       TableInfo tableInfo = DataAccess::getPostgisTableInfo(dataSeriesProvider, dataset);
 
       std::string tableName = tableInfo.tableName;
-      std::string layerName = terrama2::core::simplifyString(viewPtr->viewName + "_" + std::to_string(viewPtr->id));
+      std::string layerName = generateLayerName(viewPtr->viewName, viewPtr->id);
       std::string timestampPropertyName = tableInfo.timestampPropertyName;
 
       std::unique_ptr<te::da::DataSetType> modelDataSetType = std::move(tableInfo.dataSetType);
@@ -1253,7 +1253,7 @@ void terrama2::services::view::core::GeoServer::cleanup(const ViewId& id,
     workspace_to_remove = generateWorkspaceName(id);
 
     // Try to remove cached view table
-    const std::string& tableName = viewName + std::to_string(id);
+    const std::string& tableName = generateLayerName(viewName, id);
     // Removing view table
     try
     {
@@ -1267,11 +1267,11 @@ void terrama2::services::view::core::GeoServer::cleanup(const ViewId& id,
 
     if (dataProvider != nullptr)
     {
-      QUrl uri(dataProvider->uri.c_str());
-      const std::string& layerName = generateLayerName(viewName, id);
+      QUrl uri((dataProvider->uri+ "/" + tableName + ".properties").c_str());
+      removeFile(uri.toLocalFile().toStdString());
 
-      removeFile(uri.toString().toStdString() + "/" + layerName + ".properties");
-      removeFile(uri.toString().toStdString() + "/datastore.properties");
+      uri.setUrl((dataProvider->uri + "/datastore.properties").c_str());
+      removeFile(uri.toLocalFile().toStdString());
     }
   }
 

--- a/src/terrama2/services/view/core/data-access/Geoserver.cpp
+++ b/src/terrama2/services/view/core/data-access/Geoserver.cpp
@@ -1243,7 +1243,6 @@ std::unique_ptr<te::se::Style> terrama2::services::view::core::GeoServer::genera
 }
 
 void terrama2::services::view::core::GeoServer::cleanup(const ViewId& id,
-                                                        const std::string& viewName,
                                                         terrama2::core::DataProviderPtr dataProvider,
                                                         std::shared_ptr<terrama2::core::ProcessLogger> logger)
 {

--- a/src/terrama2/services/view/core/data-access/Geoserver.cpp
+++ b/src/terrama2/services/view/core/data-access/Geoserver.cpp
@@ -1572,8 +1572,6 @@ std::vector<std::string> terrama2::services::view::core::GeoServer::registerMosa
     /*
      * Resetting properties files tree.
      * Now we defined a sub directory containing both LayerName.properties and datastore.properties.
-     *
-     * For each execution, we reset this folder and rewrite with new files. Its important due ViewName may change.
      */
     recreateFolder(url.path().toStdString());
     // Creating LayerName.properties
@@ -2063,5 +2061,5 @@ std::string terrama2::services::view::core::GeoServer::generateWorkspaceName(con
 
 std::string terrama2::services::view::core::GeoServer::generateLayerName(const ViewId& id) const
 {
-  return terrama2::core::simplifyString("view_" + std::to_string(id));
+  return "view" + std::to_string(id);
 }

--- a/src/terrama2/services/view/core/data-access/Geoserver.cpp
+++ b/src/terrama2/services/view/core/data-access/Geoserver.cpp
@@ -236,7 +236,7 @@ QJsonObject terrama2::services::view::core::GeoServer::generateLayers(const View
       TableInfo tableInfo = DataAccess::getPostgisTableInfo(dataSeriesProvider, dataset);
 
       std::string tableName = tableInfo.tableName;
-      std::string layerName = generateLayerName(viewPtr->viewName, viewPtr->id);
+      std::string layerName = generateLayerName(viewPtr->id);
       std::string timestampPropertyName = tableInfo.timestampPropertyName;
 
       std::unique_ptr<te::da::DataSetType> modelDataSetType = std::move(tableInfo.dataSetType);
@@ -1252,7 +1252,7 @@ void terrama2::services::view::core::GeoServer::cleanup(const ViewId& id,
     workspace_to_remove = generateWorkspaceName(id);
 
     // Try to remove cached view table
-    const std::string& tableName = generateLayerName("view", id);
+    const std::string& tableName = generateLayerName(id);
     // Removing view table
     try
     {
@@ -1266,7 +1266,7 @@ void terrama2::services::view::core::GeoServer::cleanup(const ViewId& id,
 
     if (dataProvider != nullptr)
     {
-      QUrl uri((dataProvider->uri+ "/" + tableName).c_str());
+      const QUrl uri((dataProvider->uri+ "/" + tableName).c_str());
       removeFolder(uri.toLocalFile().toStdString());
     }
   }
@@ -1560,7 +1560,7 @@ std::vector<std::string> terrama2::services::view::core::GeoServer::registerMosa
 
   for(auto& dataset : inputDataSeries->datasetList)
   {
-    std::string layerName = generateLayerName("view", viewPtr->id);
+    std::string layerName = generateLayerName(viewPtr->id);
     std::transform(layerName.begin(), layerName.end(),layerName.begin(), ::tolower);
 
     QUrl url(baseUrl.toString() + QString::fromStdString("/" + terrama2::core::getFolderMask(dataset) + "/" + layerName));
@@ -2061,7 +2061,7 @@ std::string terrama2::services::view::core::GeoServer::generateWorkspaceName(con
   return "terrama2_" + std::to_string(id);
 }
 
-std::string terrama2::services::view::core::GeoServer::generateLayerName(const std::string& viewName, const ViewId& id) const
+std::string terrama2::services::view::core::GeoServer::generateLayerName(const ViewId& id) const
 {
-  return terrama2::core::simplifyString(viewName + "_" + std::to_string(id));
+  return terrama2::core::simplifyString("view_" + std::to_string(id));
 }

--- a/src/terrama2/services/view/core/data-access/Geoserver.hpp
+++ b/src/terrama2/services/view/core/data-access/Geoserver.hpp
@@ -51,6 +51,10 @@
 
 namespace terrama2
 {
+  namespace core
+  {
+    class ProcessLogger;
+  }
   namespace services
   {
     namespace view
@@ -203,7 +207,10 @@ namespace terrama2
              *
              * \param v - Current view id object to remove. Default is selected workspace
              */
-            void cleanup(const ViewId& id = 0) override;
+            void cleanup(const ViewId& id = 0,
+                         const std::string& viewName = "",
+                         terrama2::core::DataProviderPtr dataProvider = nullptr,
+                         std::shared_ptr<terrama2::core::ProcessLogger> logger = nullptr) override;
 
 
             /*!
@@ -381,9 +388,15 @@ namespace terrama2
              */
             std::string generateWorkspaceName(const ViewId& id);
 
+            /*!
+             * \brief Retrieves a layer name based view name and view id.
+             * \param view View object
+             * \return Unique Layer Name
+             */
+            std::string generateLayerName(const std::string& viewName, const ViewId& id) const;
+
 
             std::string workspace_ = "terrama2"; /*!< A workspace to work in GeoServer */
-
         };
       }
     }

--- a/src/terrama2/services/view/core/data-access/Geoserver.hpp
+++ b/src/terrama2/services/view/core/data-access/Geoserver.hpp
@@ -208,7 +208,6 @@ namespace terrama2
              * \param v - Current view id object to remove. Default is selected workspace
              */
             void cleanup(const ViewId& id = 0,
-                         const std::string& viewName = "",
                          terrama2::core::DataProviderPtr dataProvider = nullptr,
                          std::shared_ptr<terrama2::core::ProcessLogger> logger = nullptr) override;
 

--- a/src/terrama2/services/view/core/data-access/Geoserver.hpp
+++ b/src/terrama2/services/view/core/data-access/Geoserver.hpp
@@ -388,11 +388,11 @@ namespace terrama2
             std::string generateWorkspaceName(const ViewId& id);
 
             /*!
-             * \brief Retrieves a layer name based view name and view id.
-             * \param view View object
+             * \brief Helper to retrieve common view name with view id.
+             * \param id View identifier
              * \return Unique Layer Name
              */
-            std::string generateLayerName(const std::string& viewName, const ViewId& id) const;
+            std::string generateLayerName(const ViewId& id) const;
 
 
             std::string workspace_ = "terrama2"; /*!< A workspace to work in GeoServer */


### PR DESCRIPTION
### Overview

These changes improves View Service management. Now, the auto-cleanup environment such GeoServer workspace, properties files and table management are working properly.  The view are stored in database as `view` + `viewID` to avoid unnecessary table creation whenever view name changed and their files contains absolute path to data file.

Tasks:
- [x] Set absolute path in View Creation.
- [x] Performing auto cleanup:
    - GeoServer & Properties files;
    - View Table.
- [x] Fixing view name generation.