### PR TITLE
Fix View Monitored Object Result SRID

### DIFF
--- a/src/terrama2/services/view/core/data-access/Geoserver.cpp
+++ b/src/terrama2/services/view/core/data-access/Geoserver.cpp
@@ -693,6 +693,9 @@ void terrama2::services::view::core::GeoServer::registerPostgisTable(const std::
       srid = std::to_string(geomProperty->getSRID());
     }
 
+    // Configuring SRID on Root XML configuration
+    xml += "<srs>EPSG:" + srid + "</srs>";
+
     metadataSQL = "<entry key=\"JDBC_VIRTUAL_TABLE\">"
                   "<virtualTable>"
                   "<name>"+layerName+"</name>" +


### PR DESCRIPTION
Sometimes, the GeoServer does not recognizes analysis result SRID (even supporting) and compute incorrect extent. This change sets this configuration manually to avoid GeoServer auto configure.