### PR TITLE
Occurrence postgis timestamp column

### DIFF
--- a/share/terrama2/semantics/occurrence-postgis.json
+++ b/share/terrama2/semantics/occurrence-postgis.json
@@ -14,9 +14,13 @@
           "table_name": {
             "type": "string",
             "title": "Table Name"
+          },
+          "timestamp_property": {
+            "type": "string",
+            "title": "Timestamp property"
           }
         },
-        "required": ["table_name"]
+        "required": ["table_name", "timestamp_property"]
       },
       "form": ["*"]
     }

--- a/share/terrama2/semantics/occurrence-postgis.json
+++ b/share/terrama2/semantics/occurrence-postgis.json
@@ -18,9 +18,13 @@
           "timestamp_property": {
             "type": "string",
             "title": "Timestamp property"
+          },
+          "geometry_property": {
+            "type": "string",
+            "title": "Geometry property"
           }
         },
-        "required": ["table_name", "timestamp_property"]
+        "required": ["table_name", "timestamp_property", "geometry_property"]
       },
       "form": ["*"]
     }

--- a/src/terrama2/impl/DataAccessorOccurrenceWfp.cpp
+++ b/src/terrama2/impl/DataAccessorOccurrenceWfp.cpp
@@ -84,7 +84,7 @@ void terrama2::core::DataAccessorOccurrenceWfp::adapt(DataSetPtr dataSet, std::s
 
   te::dt::DateTimeProperty* dateProperty = new te::dt::DateTimeProperty("data", te::dt::DATE);
   te::dt::DateTimeProperty* timeProperty = new te::dt::DateTimeProperty("hora", te::dt::TIME_DURATION);
-  te::dt::DateTimeProperty* timestampProperty = new te::dt::DateTimeProperty(getTimestampPropertyName(dataSet), te::dt::TIME_INSTANT);
+  te::dt::DateTimeProperty* timestampProperty = new te::dt::DateTimeProperty(getTimestampPropertyName(dataSet), te::dt::TIME_INSTANT_TZ);
   te::dt::SimpleProperty* latProperty = new te::dt::SimpleProperty(getLatitudePropertyName(dataSet), te::dt::DOUBLE_TYPE);
   te::dt::SimpleProperty* lonProperty = new te::dt::SimpleProperty(getLongitudePropertyName(dataSet), te::dt::DOUBLE_TYPE);
   te::gm::GeometryProperty* geomProperty = new te::gm::GeometryProperty(getOutputGeometryPropertyName(dataSet), srid, te::gm::PointType);

--- a/src/terrama2/impl/DataAccessorPostGIS.cpp
+++ b/src/terrama2/impl/DataAccessorPostGIS.cpp
@@ -213,9 +213,13 @@ void terrama2::core::DataAccessorPostGIS::addGeometryFilter(terrama2::core::Data
     std::vector<std::string>& whereConditions) const
 {
   if(filter.region.get())
+  {
+    std::unique_ptr<te::gm::Geometry> geom(static_cast<te::gm::Geometry*>(filter.region->clone()));
+    geom->transform(4326);
     whereConditions.push_back("ST_INTERSECTS(ST_Transform(t." + getGeometryPropertyName(dataSet)
-                              + ", " + std::to_string(filter.region->getSRID())
-                              + "), ST_GeomFromEWKT('SRID=" + std::to_string(filter.region->getSRID()) + ";" +filter.region->asText()+"'))");
+                              + ", " + std::to_string(geom->getSRID())
+                              + "), ST_GeomFromEWKT('SRID=" + std::to_string(geom->getSRID()) + ";" +geom->asText()+"'))");
+  }
 }
 
 void terrama2::core::DataAccessorPostGIS::updateLastTimestamp(DataSetPtr dataSet, std::shared_ptr<te::da::DataSourceTransactor> transactor) const

--- a/src/terrama2/impl/DataStoragerTable.cpp
+++ b/src/terrama2/impl/DataStoragerTable.cpp
@@ -115,7 +115,7 @@ void terrama2::core::DataStoragerTable::store(DataSetSeries series, DataSetPtr o
       if(typeCapabilities.supportsBTreeIndex())
       {
         // the newDataSetType takes ownership of the pointer
-        auto spatialIndex = new te::da::Index("spatial_index", te::da::B_TREE_TYPE, {geomProperty});
+        auto spatialIndex = new te::da::Index("spatial_index_" + destinationDataSetName, te::da::B_TREE_TYPE, {geomProperty});
         newDataSetType->add(spatialIndex);
       }
     }


### PR DESCRIPTION
- The occurrence postgis semantics wasn't requiring a timestamp and a geometry column.
- When transforming a geometry in UTM projection there were cases where the data could be out of the utm zone, now everything is transformed to EPSG:4326 (latlong-wgs84)
- Including Timezone to occurrence wfp to fix geoserver bug