### PR TITLE
Fix dcp postions table

### DIFF
--- a/src/terrama2/core/data-access/DataAccessor.cpp
+++ b/src/terrama2/core/data-access/DataAccessor.cpp
@@ -221,8 +221,13 @@ terrama2::core::DataAccessor::getSeries(const std::map<DataSetId, std::string> u
         DataSetSeries tempSeries = getSeries(uriMap.at(dataset->id), filter, dataset, remover);
         series.emplace(dataset, tempSeries);
       }
+      catch(const std::out_of_range&)
+      {
+        // no data in the dataset
+      }
       catch (const terrama2::core::NoDataException&)
       {
+        // no data in the dataset
       }
     }//for each dataset
 

--- a/src/terrama2/core/utility/GeoUtils.hpp
+++ b/src/terrama2/core/utility/GeoUtils.hpp
@@ -6,6 +6,8 @@
 #include <terralib/raster/Raster.h>
 #include <terralib/raster/Grid.h>
 
+#include "../data-access/DataSetSeries.hpp"
+
 namespace terrama2 {
   namespace core {
     /*!
@@ -51,5 +53,11 @@ namespace terrama2 {
     */
     std::pair<uint32_t, uint32_t> geoToGrid(const te::gm::Coord2D& coord, te::rst::Grid* grid);
 
+    /*
+        \brief creates an RTree from the geometrict property of the DataSetSeries
+
+        \warning The RTree return is in EPSG:4326
+    */
+    std::unique_ptr<te::sam::rtree::Index<size_t, 8> > createRTreeFromSeries(const terrama2::core::DataSetSeries& dataSetSeries);
   } /* core */
 } /* terrama2 */

--- a/src/terrama2/core/utility/ProcessLogger.cpp
+++ b/src/terrama2/core/utility/ProcessLogger.cpp
@@ -282,7 +282,8 @@ void terrama2::core::ProcessLogger::result(Status status, const std::shared_ptr<
   QString timestamp = "NULL";
 
 
-  if(dataTimestamp != nullptr)
+  if((dataTimestamp != nullptr)
+     && (!dataTimestamp->getTimeInstantTZ().is_special()))
   {
     verify::date(dataTimestamp);
 

--- a/src/terrama2/impl/DataAccessorFile.cpp
+++ b/src/terrama2/impl/DataAccessorFile.cpp
@@ -30,6 +30,7 @@
 #include "DataAccessorFile.hpp"
 #include "../core/utility/FilterUtils.hpp"
 #include "../core/utility/TimeUtils.hpp"
+#include "../core/utility/GeoUtils.hpp"
 #include "../core/utility/Logger.hpp"
 #include "../core/utility/Raii.hpp"
 #include "../core/utility/Utils.hpp"
@@ -129,18 +130,31 @@ void terrama2::core::DataAccessorFile::filterDataSet(std::shared_ptr<te::mem::Da
   size_t geomColumn = te::da::GetFirstPropertyPos(completeDataSet.get(), te::dt::GEOMETRY_TYPE);
   size_t rasterColumn = te::da::GetFirstPropertyPos(completeDataSet.get(), te::dt::RASTER_TYPE);
 
-  std::unordered_map<terrama2::core::DataSetPtr, terrama2::core::DataSetSeries > seriesStaticData;
+  terrama2::core::DataSetSeries filterDataSetSeries;
+  std::unique_ptr<te::sam::rtree::Index<size_t, 8> > rtree;
   // Apply filter by static data
   if(filter.dataProvider && filter.dataSeries)
   {
     auto dataAccesor = DataAccessorFactory::getInstance().make(filter.dataProvider, filter.dataSeries);
 
     terrama2::core::Filter emptyFilter;
-    seriesStaticData = dataAccesor->getSeries(emptyFilter, nullptr);
+    std::unordered_map<terrama2::core::DataSetPtr, terrama2::core::DataSetSeries > seriesStaticData = dataAccesor->getSeries(emptyFilter, nullptr);
 
     if(seriesStaticData.empty())
     {
       QString errMsg = QObject::tr("No data available for data series '%1'.").arg(filter.dataSeries->name.c_str());
+      TERRAMA2_LOG_WARNING() << errMsg;
+      throw terrama2::core::NoDataException() << ErrorDescription(errMsg);
+    }
+
+    if(seriesStaticData.size() == 1)
+    {
+      filterDataSetSeries = seriesStaticData.begin()->second;
+      rtree = terrama2::core::createRTreeFromSeries(filterDataSetSeries);
+    }
+    else
+    {
+      QString errMsg = QObject::tr("Error loading data series '%1'.").arg(filter.dataSeries->name.c_str());
       TERRAMA2_LOG_WARNING() << errMsg;
       throw terrama2::core::NoDataException() << ErrorDescription(errMsg);
     }
@@ -153,8 +167,8 @@ void terrama2::core::DataAccessorFile::filterDataSet(std::shared_ptr<te::mem::Da
   {
     completeDataSet->move(i);
     if(!isValidTimestamp(completeDataSet, filter, dateColumn)
-        || !isValidGeometry(completeDataSet, filter, geomColumn, seriesStaticData)
-        || !isValidRaster(completeDataSet, filter, rasterColumn, seriesStaticData))
+        || !isValidGeometry(completeDataSet, filter, geomColumn, filterDataSetSeries, rtree)
+        || !isValidRaster(completeDataSet, filter, rasterColumn, filterDataSetSeries, rtree))
     {
       completeDataSet->remove();
       --size;
@@ -287,7 +301,10 @@ bool terrama2::core::DataAccessorFile::isValidTimestamp(std::shared_ptr<te::mem:
   return true;
 }
 
-bool terrama2::core::DataAccessorFile::isValidGeometry(std::shared_ptr<te::mem::DataSet> dataSet, const Filter& filter, size_t geomColumn, std::unordered_map<DataSetPtr, DataSetSeries>& seriesStaticData) const
+bool terrama2::core::DataAccessorFile::isValidGeometry(std::shared_ptr<te::mem::DataSet> dataSet,
+                                                       const Filter& filter, size_t geomColumn,
+                                                       terrama2::core::DataSetSeries filterDataSetSeries,
+                                                       const std::unique_ptr<te::sam::rtree::Index<size_t, 8> >& rtree) const
 {
   if(!isValidColumn(geomColumn))
     return true;
@@ -311,40 +328,42 @@ bool terrama2::core::DataAccessorFile::isValidGeometry(std::shared_ptr<te::mem::
   }
 
 
-  if(!seriesStaticData.empty())
+  if(rtree)
   {
-    for(auto& it : seriesStaticData)
-    {
-      auto syncDs = it.second.syncDataSet;
-      std::size_t geomPropertyPosition = te::da::GetFirstPropertyPos(syncDs->dataset().get(), te::dt::GEOMETRY_TYPE);
-      te::gm::GeometryProperty* property = dynamic_cast<te::gm::GeometryProperty*>(it.second.teDataSetType->getProperty(geomPropertyPosition));
+    // the RTree is create with EPSG:4326
+    region->transform(4326);
+    auto box = region->getMBR();
+    std::vector<std::size_t> report;
+    rtree->search(*box, report);
 
-      auto extentDs = syncDs->getExtent(geomPropertyPosition);
-      std::shared_ptr<te::gm::Geometry> envelopeGeom(te::gm::GetGeomFromEnvelope(extentDs.get(), property->getSRID()));
-      region->transform(property->getSRID());
-      if(region->intersects(envelopeGeom.get()))
+    auto syncDs = filterDataSetSeries.syncDataSet;
+    std::size_t geomPropertyPos = te::da::GetFirstPropertyPos(syncDs->dataset().get(), te::dt::GEOMETRY_TYPE);
+    if(geomPropertyPos == std::numeric_limits<std::size_t>::max())
+    {
+      QString errMsg(QObject::tr("Could not find a geometry property in the indexed dataset"));
+      TERRAMA2_LOG_ERROR() << errMsg;
+      throw terrama2::InvalidArgumentException() << terrama2::ErrorDescription(errMsg);
+    }
+
+    for(size_t i = 0; i < report.size(); ++i) {
+      auto geom = syncDs->getGeometry(i, geomPropertyPos);
+      if (region->intersects(geom.get()))
       {
-        for(unsigned int j = 0; j < syncDs->size(); ++j)
-        {
-          auto geom = syncDs->getGeometry(j, geomPropertyPosition);
-          if(region->intersects(geom->getEnvelope()))
-          {
-            if (region->intersects(geom.get()))
-            {
-              return true;
-            }
-          }
-        }
+        return true;
       }
     }
 
     return false;
   }
-  return true;
 
+  return true;
 }
 
-bool terrama2::core::DataAccessorFile::isValidRaster(std::shared_ptr<te::mem::DataSet> dataSet, const Filter&  filter, size_t rasterColumn, std::unordered_map<DataSetPtr, DataSetSeries>& seriesStaticData) const
+bool terrama2::core::DataAccessorFile::isValidRaster(std::shared_ptr<te::mem::DataSet> dataSet,
+                                                     const Filter&  filter,
+                                                     size_t rasterColumn,
+                                                     terrama2::core::DataSetSeries filterDataSetSeries,
+                                                     const std::unique_ptr<te::sam::rtree::Index<size_t, 8> >& rtree) const
 {
   if(!isValidColumn(rasterColumn))
     return true;
@@ -377,61 +396,58 @@ bool terrama2::core::DataAccessorFile::isValidRaster(std::shared_ptr<te::mem::Da
     }
   }
 
-  //if filter by dataseries
-  if(!seriesStaticData.empty())
+  if(rtree)
   {
-    for(auto& it : seriesStaticData)
+    std::shared_ptr<te::gm::Geometry> region(te::gm::GetGeomFromEnvelope(raster->getExtent(raster->getSRID()), raster->getSRID()));
+    // the RTree is create with EPSG:4326
+    region->transform(4326);
+    auto box = region->getMBR();
+    std::vector<std::size_t> report;
+    rtree->search(*box, report);
+
+    auto syncDs = filterDataSetSeries.syncDataSet;
+    std::size_t geomPropertyPos = te::da::GetFirstPropertyPos(syncDs->dataset().get(), te::dt::GEOMETRY_TYPE);
+    if(geomPropertyPos == std::numeric_limits<std::size_t>::max())
     {
-      std::shared_ptr<te::gm::Geometry> rasterBox(te::gm::GetGeomFromEnvelope(raster->getExtent(raster->getSRID()), raster->getSRID()));
-
-      auto syncDs = it.second.syncDataSet;
-      std::size_t geomPropertyPosition = te::da::GetFirstPropertyPos(syncDs->dataset().get(), te::dt::GEOMETRY_TYPE);
-
-      auto teDataset = syncDs->dataset();
-      if(teDataset->moveBeforeFirst())
-      {
-        //create a union of all geometries of the dataset
-        std::shared_ptr<te::gm::Geometry> unitedGeom;
-        bool first = true;
-        while (teDataset->moveNext())
-        {
-          if(teDataset->isNull(geomPropertyPosition))
-            continue;
-
-          if(first)
-          {
-            unitedGeom = std::shared_ptr<te::gm::Geometry>(teDataset->getGeometry(geomPropertyPosition));
-            first = false;
-            continue;
-          }
-
-          auto geom(teDataset->getGeometry(geomPropertyPosition));
-          unitedGeom = std::shared_ptr<te::gm::Geometry>(unitedGeom->Union(geom.release()));
-        }
-
-        unitedGeom->transform(rasterBox->getSRID());
-        //check if the raster intersects the data
-        if(!rasterBox->intersects(unitedGeom.get()))
-          return false;
-
-        //crop the raster using the dataset
-        if(filter.cropRaster)
-        {
-          //clip raster by union
-          auto clipedRaster = raster->clip({unitedGeom.get()}, {}, "EXPANSIBLE");
-          //update raster in the dataset
-          dataSet->setRaster(rasterColumn, clipedRaster);
-          //update raster for consistency in the function
-          raster = std::shared_ptr< te::rst::Raster >(dataSet->getRaster(rasterColumn));
-        }
-      }
-      else
-      {
-        QString errMsg = QObject::tr("Invalid filter dataseries.");
-        TERRAMA2_LOG_WARNING() << errMsg;
-        throw terrama2::core::DataAccessException() << ErrorDescription(errMsg);
-      }
+      QString errMsg(QObject::tr("Could not find a geometry property in the indexed dataset"));
+      TERRAMA2_LOG_ERROR() << errMsg;
+      throw terrama2::InvalidArgumentException() << terrama2::ErrorDescription(errMsg);
     }
+
+    // create a union of all geometries of the dataset
+    // this is needed for the crop operation
+    std::shared_ptr<te::gm::Geometry> unitedGeom;
+    bool first = true;
+    for(size_t i = 0; i < report.size(); ++i) {
+      auto sharedGeom = syncDs->getGeometry(i, geomPropertyPos);
+      auto geom = static_cast<te::gm::Geometry*>(sharedGeom->clone());
+      if(first)
+      {
+        unitedGeom.reset(geom);
+        first = false;
+        continue;
+      }
+
+      unitedGeom = std::shared_ptr<te::gm::Geometry>(unitedGeom->Union(geom));
+    }
+
+    if (region->intersects(unitedGeom.get()))
+    {
+      //crop the raster using the dataset
+      if(filter.cropRaster)
+      {
+        //clip raster by union
+        auto clipedRaster = raster->clip({unitedGeom.get()}, {}, "EXPANSIBLE");
+        //update raster in the dataset
+        dataSet->setRaster(rasterColumn, clipedRaster);
+        //update raster for consistency in the function
+        raster = std::shared_ptr< te::rst::Raster >(dataSet->getRaster(rasterColumn));
+      }
+
+      return true;
+    }
+
+    return false;
   }
 
   return true;

--- a/src/terrama2/impl/DataAccessorFile.hpp
+++ b/src/terrama2/impl/DataAccessorFile.hpp
@@ -186,7 +186,11 @@ namespace terrama2
 
         */
 
-        virtual bool isValidGeometry(std::shared_ptr<te::mem::DataSet> dataSet, const Filter& filter, size_t geomColumn, std::unordered_map<DataSetPtr, DataSetSeries>& seriesStaticData) const;
+        virtual bool isValidGeometry(std::shared_ptr<te::mem::DataSet> dataSet,
+                                     const Filter& filter,
+                                     size_t geomColumn,
+                                     terrama2::core::DataSetSeries filterDataSetSeries,
+                                     const std::unique_ptr<te::sam::rtree::Index<size_t, 8> >& rtree) const;
 
         /*!
           \brief Filter dataset by raster envelope
@@ -200,7 +204,10 @@ namespace terrama2
            - Raster attribute is null (will be logged)
 
         */
-        virtual bool isValidRaster(std::shared_ptr<te::mem::DataSet> dataSet, const Filter&  filter, size_t rasterColumn, std::unordered_map<DataSetPtr, DataSetSeries>& seriesStaticData) const;
+        virtual bool isValidRaster(std::shared_ptr<te::mem::DataSet> dataSet,
+                                   const Filter&  filter, size_t rasterColumn,
+                                   terrama2::core::DataSetSeries filterDataSetSeries,
+                                   const std::unique_ptr<te::sam::rtree::Index<size_t, 8> >& rtree) const;
 
         std::shared_ptr< te::dt::TimeInstantTZ > getDataLastTimestamp(DataSetPtr dataSet, std::shared_ptr<te::da::DataSet> teDataSet) const;
 

--- a/src/terrama2/services/collector/core/IntersectionOperation.cpp
+++ b/src/terrama2/services/collector/core/IntersectionOperation.cpp
@@ -110,14 +110,6 @@ terrama2::core::DataSetSeries terrama2::services::collector::core::processVector
   auto collectedData = collectedDataSetSeries.syncDataSet;
   auto collectedDataSetType = collectedDataSetSeries.teDataSetType;
 
-  if(intersectionDataSeries->semantics.dataSeriesType != terrama2::core::DataSeriesType::GEOMETRIC_OBJECT)
-  {
-    QString errMsg(QObject::tr("Invalid DataSeries type for intersection"));
-    TERRAMA2_LOG_ERROR() << errMsg;
-    throw terrama2::InvalidArgumentException() << terrama2::ErrorDescription(errMsg);
-  }
-
-
   if(!collectedData)
   {
     QString errMsg(QObject::tr("Invalid TerraLib dataset"));


### PR DESCRIPTION
Update positions table.

Old behavior:
remove and recreate the table every time

New behavior:
Update the table with new DCP

Known issues:
- Old positions are not being updated

!Important!:
Removed DCP are kept in the table for old analysis results.