### PR TITLE
Copy datasettype, romove unecessary properties from WFP

### DIFF
--- a/src/terrama2/impl/DataAccessorOccurrenceWfp.cpp
+++ b/src/terrama2/impl/DataAccessorOccurrenceWfp.cpp
@@ -82,8 +82,6 @@ void terrama2::core::DataAccessorOccurrenceWfp::adapt(DataSetPtr dataSet, std::s
 
   Srid srid = getSrid(dataSet);
 
-  te::dt::DateTimeProperty* dateProperty = new te::dt::DateTimeProperty("data", te::dt::DATE);
-  te::dt::DateTimeProperty* timeProperty = new te::dt::DateTimeProperty("hora", te::dt::TIME_DURATION);
   te::dt::DateTimeProperty* timestampProperty = new te::dt::DateTimeProperty(getTimestampPropertyName(dataSet), te::dt::TIME_INSTANT_TZ);
   te::dt::SimpleProperty* latProperty = new te::dt::SimpleProperty(getLatitudePropertyName(dataSet), te::dt::DOUBLE_TYPE);
   te::dt::SimpleProperty* lonProperty = new te::dt::SimpleProperty(getLongitudePropertyName(dataSet), te::dt::DOUBLE_TYPE);
@@ -99,10 +97,6 @@ void terrama2::core::DataAccessorOccurrenceWfp::adapt(DataSetPtr dataSet, std::s
       // datetime column found
       converter->add(i, timestampProperty,
                      boost::bind(&terrama2::core::DataAccessorOccurrenceWfp::stringToTimestamp, this, _1, _2, _3, getTimeZone(dataSet)));
-      converter->add(i, dateProperty,
-                     boost::bind(&terrama2::core::DataAccessorOccurrenceWfp::stringToDate, this, _1, _2, _3, getTimeZone(dataSet)));
-      converter->add(i, timeProperty,
-                     boost::bind(&terrama2::core::DataAccessorOccurrenceWfp::stringToTimeDuration, this, _1, _2, _3, getTimeZone(dataSet)));
     }
     else if(property->getName() == getLatitudePropertyName(dataSet) || property->getName() == getLongitudePropertyName(dataSet))
     {
@@ -176,75 +170,6 @@ te::dt::AbstractData* terrama2::core::DataAccessorOccurrenceWfp::stringToTimesta
     boost::local_time::local_date_time date(boostDate.date(), boostDate.time_of_day(), zone, true);
 
     return new te::dt::TimeInstant(date.utc_time());
-  }
-  catch(const std::exception& e)
-  {
-    TERRAMA2_LOG_ERROR() << e.what();
-  }
-  catch(const boost::exception& e)
-  {
-    TERRAMA2_LOG_ERROR() << boost::get_error_info<terrama2::ErrorDescription>(e);
-  }
-  catch(...)
-  {
-    TERRAMA2_LOG_ERROR() << "Unknown error";
-  }
-
-  return nullptr;
-}
-
-te::dt::AbstractData* terrama2::core::DataAccessorOccurrenceWfp::stringToTimeDuration(te::da::DataSet *dataset,
-                                                                                      const std::vector<std::size_t> &indexes,
-                                                                                      int /*dstType*/,
-                                                                                      const std::string &timezone) const
-{
-  assert(indexes.size() == 1);
-
-  try
-  {
-    std::string dateTime = dataset->getString(indexes[0]);
-
-    boost::posix_time::ptime boostDate(boost::posix_time::time_from_string(dateTime));
-
-    boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone(timezone));
-    boost::local_time::local_date_time date(boostDate.date(), boostDate.time_of_day(), zone, true);
-
-    boost::posix_time::time_duration timeDuration = date.utc_time().time_of_day();
-    return new te::dt::TimeDuration(timeDuration);
-  }
-  catch(const std::exception& e)
-  {
-    TERRAMA2_LOG_ERROR() << e.what();
-  }
-  catch(const boost::exception& e)
-  {
-    TERRAMA2_LOG_ERROR() << boost::get_error_info<terrama2::ErrorDescription>(e);
-  }
-  catch(...)
-  {
-    TERRAMA2_LOG_ERROR() << "Unknown error";
-  }
-
-  return nullptr;
-}
-
-te::dt::AbstractData* terrama2::core::DataAccessorOccurrenceWfp::stringToDate(te::da::DataSet* dataset,
-                                                                const std::vector<std::size_t>& indexes, int /*dstType*/,
-                                                                const std::string& timezone) const
-{
-  assert(indexes.size() == 1);
-
-  try
-  {
-    std::string dateTime = dataset->getString(indexes[0]);
-    if(dateTime.empty())
-      return nullptr;
-
-    boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone(timezone));
-    boost::posix_time::ptime boostDate(boost::posix_time::time_from_string(dateTime));
-    boost::local_time::local_date_time date(boostDate.date(), boostDate.time_of_day(), zone, true);
-
-    return new te::dt::Date(date.utc_time().date());
   }
   catch(const std::exception& e)
   {

--- a/src/terrama2/impl/DataAccessorOccurrenceWfp.hpp
+++ b/src/terrama2/impl/DataAccessorOccurrenceWfp.hpp
@@ -82,14 +82,6 @@ namespace terrama2
         te::dt::AbstractData* stringToTimestamp(te::da::DataSet* dataset, const std::vector<std::size_t>& indexes, int /*dstType*/,
                                                 const std::string& timezone) const;
 
-        //! Convert a string to a time duration value
-        te::dt::AbstractData* stringToTimeDuration(te::da::DataSet *dataset, const std::vector<std::size_t> &indexes,
-                                                   int /*dstType*/, const std::string &timezone) const;
-
-        //! Convert a string to a date value
-        te::dt::AbstractData* stringToDate(te::da::DataSet* dataset, const std::vector<std::size_t>& indexes, int /*dstType*/,
-                                                const std::string& timezone) const;
-
         //! Convert string to Geometry
         te::dt::AbstractData* stringToPoint(te::da::DataSet* dataset, const std::vector<std::size_t>& indexes, int dstType, const Srid& srid) const;
     };

--- a/src/terrama2/impl/DataStoragerTable.cpp
+++ b/src/terrama2/impl/DataStoragerTable.cpp
@@ -42,6 +42,7 @@
 #include <terralib/geometry/GeometryProperty.h>
 #include <terralib/datatype/StringProperty.h>
 #include <terralib/datatype/DateTimeProperty.h>
+#include <terralib/datatype/NumericProperty.h>
 #include <terralib/dataaccess/utils/Utils.h>
 
 //Qt
@@ -70,17 +71,47 @@ std::unique_ptr<te::dt::Property> terrama2::core::DataStoragerTable::copyPropert
     case te::dt::DOUBLE_TYPE:
       return std::unique_ptr<te::dt::Property>(new te::dt::SimpleProperty(name, type, true));
     case te::dt::STRING_TYPE:
-      return std::unique_ptr<te::dt::Property>(new te::dt::StringProperty(name));
-    case te::dt::DATETIME_TYPE:
-      auto dateTime = dynamic_cast<te::dt::DateTimeProperty*>(property);
-      if(!dateTime)
       {
-        QString errMsg = QObject::tr("Invalid property %1 with type %2").arg(QString::fromStdString(name), int(type));
-        TERRAMA2_LOG_ERROR() << errMsg;
-        throw DataStoragerException() << ErrorDescription(errMsg);
-      }
+        auto stringProperty = dynamic_cast<te::dt::StringProperty*>(property);
+        if(!stringProperty)
+        {
+          QString errMsg = QObject::tr("Invalid property %1 with type %2").arg(QString::fromStdString(name), int(type));
+          TERRAMA2_LOG_ERROR() << errMsg;
+          throw DataStoragerException() << ErrorDescription(errMsg);
+        }
 
-      return std::unique_ptr<te::dt::Property>(new te::dt::DateTimeProperty(name));
+        return std::unique_ptr<te::dt::Property>(new te::dt::StringProperty(name,
+                                                                            stringProperty->getSubType(),
+                                                                            stringProperty->size()));
+      }
+    case te::dt::DATETIME_TYPE:
+      {
+        auto dateTime = dynamic_cast<te::dt::DateTimeProperty*>(property);
+        if(!dateTime)
+        {
+          QString errMsg = QObject::tr("Invalid property %1 with type %2").arg(QString::fromStdString(name), int(type));
+          TERRAMA2_LOG_ERROR() << errMsg;
+          throw DataStoragerException() << ErrorDescription(errMsg);
+        }
+
+        return std::unique_ptr<te::dt::Property>(new te::dt::DateTimeProperty(name,
+                                                                              dateTime->getSubType(),
+                                                                              dateTime->getPrecision()));
+      }
+    case te::dt::NUMERIC_TYPE:
+      {
+        auto numericProperty = dynamic_cast<te::dt::NumericProperty*>(property);
+        if(!numericProperty)
+        {
+          QString errMsg = QObject::tr("Invalid property %1 with type %2").arg(QString::fromStdString(name), int(type));
+          TERRAMA2_LOG_ERROR() << errMsg;
+          throw DataStoragerException() << ErrorDescription(errMsg);
+        }
+
+        return std::unique_ptr<te::dt::Property>(new te::dt::NumericProperty(name,
+                                                                             numericProperty->getPrecision(),
+                                                                             numericProperty->getScale()));
+      }
     default:
       /* code */
       break;

--- a/src/terrama2/impl/DataStoragerTable.hpp
+++ b/src/terrama2/impl/DataStoragerTable.hpp
@@ -57,6 +57,8 @@ namespace terrama2
         bool isPropertyEqual(te::dt::Property* newProperty, te::dt::Property* oldMember) const;
 
       protected:
+        std::unique_ptr<te::dt::Property> copyProperty(te::dt::Property* property) const;
+        std::shared_ptr<te::da::DataSetType> copyDataSetType(std::shared_ptr<te::da::DataSetType> dataSetType) const;
         virtual std::string driver() const = 0;
     };
   }

--- a/src/terrama2/impl/DataStoragerTable.hpp
+++ b/src/terrama2/impl/DataStoragerTable.hpp
@@ -58,7 +58,7 @@ namespace terrama2
 
       protected:
         std::unique_ptr<te::dt::Property> copyProperty(te::dt::Property* property) const;
-        std::shared_ptr<te::da::DataSetType> copyDataSetType(std::shared_ptr<te::da::DataSetType> dataSetType) const;
+        std::shared_ptr<te::da::DataSetType> copyDataSetType(std::shared_ptr<te::da::DataSetType> dataSetType, const std::string& newDataSetName) const;
         virtual std::string driver() const = 0;
     };
   }

--- a/src/unittest/core/TsDataAccessorOccurrenceWfp.cpp
+++ b/src/unittest/core/TsDataAccessorOccurrenceWfp.cpp
@@ -532,16 +532,17 @@ void TsDataAccessorOccurrenceWfp::TestOK()
     QFile file(url.path());
     file.open(QIODevice::QIODevice::ReadOnly);
 
-    int numberLinesOriginalFile = -1;
+    std::size_t numberLinesOriginalFile = 0;
     // Get Number Lines Original File.
     while (!file.atEnd())
     {
       file.readLine();
       ++numberLinesOriginalFile;
     }
+    // first line is header
+    --numberLinesOriginalFile;
 
     QStringList numberPropertiesOriginalFile;
-
     if(file.seek(0))
     {
       // Get number Properties Original File.
@@ -549,20 +550,17 @@ void TsDataAccessorOccurrenceWfp::TestOK()
       QString line = in.readLine();
       numberPropertiesOriginalFile = line.split(",");
     }
-
-    numberPropertiesOriginalFile.removeFirst();
-
     file.close();
 
     // Get Number Properties New File.
-    int numberPropertiesNewFile = teDataSet->getNumProperties();
+    auto numberPropertiesNewFile = teDataSet->getNumProperties();
 
     // Get Number Lines New File.
-    int numberLinesNewFile = teDataSet->size();
+    auto numberLinesNewFile = teDataSet->size();
 
     QCOMPARE(numberLinesOriginalFile,numberLinesNewFile);
-    QCOMPARE(numberPropertiesOriginalFile.size(), 3);
-    QCOMPARE(numberPropertiesNewFile, 7);
+    QCOMPARE(numberPropertiesOriginalFile.size(), 4);
+    QCOMPARE(numberPropertiesNewFile, 3ul);
   }
   catch(...)
   {


### PR DESCRIPTION
Copy the DataSetTyoe without using the clone method, the properties won't inherit modifiers like 'not null'.

Properties removed from DataAcessorWFP:
  - lat
  - long
  - hora
  - data