### PR TITLE
Fix process to generate registered view

### DIFF
--- a/webapp/core/DataManager.js
+++ b/webapp/core/DataManager.js
@@ -2099,7 +2099,7 @@ var DataManager = module.exports = {
               });
               promises.push(removeProvider);
             });
-          } 
+          }
 
           (dataSeriesObject.editedDcps !== undefined ? dataSeriesObject.editedDcps : dataSeriesObject.dataSets).forEach(function(newDataSet) {
             var dataSetToUpdate = dataSeries.dataSets.find(function(dSet){
@@ -4193,7 +4193,7 @@ var DataManager = module.exports = {
             ],
             required: false
           },
-          { 
+          {
             model: models.db.Schedule,
             include: [
               {
@@ -6046,7 +6046,7 @@ var DataManager = module.exports = {
           });
           return Promise.all(promises)
             .then(function(layers) {
-              return self.getView({id: viewResult.view_id})
+              return self.getView({id: viewResult.view_id}, options)
                 .then(function(view) {
                   return resolve(new DataModel.RegisteredView(Utils.extend(viewResult, {layers: layers, view: view})));
                 });


### PR DESCRIPTION
## Description:

Sometimes TerraMA2 is not able to save *RegisteredView*. It seems to be related with transaction operation in the method `addRegisteredView` of DataManager. The argument `options` msut be passed through `addView` to sequelize be capable of proceed with transaction.

## Reviewers:

@janosimas 

**Type:**

- [ ] New feature
- [ ] Enhancement
- [x] Bug

**Platform:**

- [x] Linux
- [ ] Mac
- [ ] Windows

**Ticket:**
- [x] Fix process to generate registered view - [113](http://www.terrama2.dpi.inpe.br/datainfo/ticket/113)

<details>
<summary><b>Changelog:<b/></summary>

*Bug fix:*
* Fix process to generate registered view using sequelize transactor

</details>
