### PR TITLE
B4.0.6

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,8 @@
 - Fix max-width size for images in webmonitor
 - Fix word wrap in webmonitor feature info
 - Alert from DCP analysis
+- Fix process to generate registered view using sequelize transactor
+- Fix intersection invalid access when static data is larger then colelcted data
 
 # 4.0.5
 

--- a/src/terrama2/services/collector/core/IntersectionOperation.cpp
+++ b/src/terrama2/services/collector/core/IntersectionOperation.cpp
@@ -275,7 +275,7 @@ terrama2::core::DataSetSeries terrama2::services::collector::core::processVector
         for(size_t k = 0; k < report.size(); ++k)
         {
           // sanity check, does the geometry exist?
-          if(collectedData->isNull(i, collectedGeomPropertyPos))
+          if(collectedData->isNull(report[k], collectedGeomPropertyPos))
             continue;
 
           std::shared_ptr<te::gm::Geometry> occurrence = collectedData->getGeometry(report[k], collectedGeomPropertyPos);


### PR DESCRIPTION
## Description:

Fix intersection invalid access when static data is larger then collected data.

Checking if the geometry existed was being made with the wrong index.

**Type:**

- [ ] New feature
- [ ] Enhancement
- [x] Bug

**Platform:**

- [x] Linux
- [x] Mac
- [x] Windows

<details>
<summary><b>Changelog:<b/></summary>

*Bug fix:*
- Fix intersection invalid access when static data is larger then collected data

</details>
