### PR TITLE
Use clang-tidy-diff and pre-commit script in docker dev

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -43,7 +43,7 @@ RUN sh -c 'echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main"
     python-clang-6.0 \
     python-lldb-6.0
 
-RUN apt install -y gdb valgrind
+RUN apt install -y gdb valgrind cppcheck
 
 # Install VSCode
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg && \
@@ -127,18 +127,31 @@ ADD ./clang_update-alternative.sh ${SCRIPTS_DIR}
 RUN cd ${SCRIPTS_DIR} && \
     ./clang_update-alternative.sh
 
-ADD install-3rdparty-linux-ubuntu-16.04.sh ${SCRIPTS_DIR}
-ADD prepare_terralib_base.sh ${SCRIPTS_DIR}
-RUN cd ${SCRIPTS_DIR} && cat prepare_terralib_base.sh | sed -e "s@\${DEPENDENCIES_DIR}@${DEPENDENCIES_DIR}@g" > prepare_terralib_base_2.sh && \
-    cat prepare_terralib_base_2.sh | sed -e "s@\${TERRALIB_DIR}@${TERRALIB_DIR}@g" > prepare_terralib_base_3.sh && \
-    cat prepare_terralib_base_3.sh | sed -e "s@\${SCRIPTS_DIR}@${SCRIPTS_DIR}@g" > prepare_terralib.sh && \
-    rm prepare_terralib_base.sh prepare_terralib_base_2.sh prepare_terralib_base_3.sh -f
+ADD clang-tidy-diff.py ${SCRIPTS_DIR}
+ADD pre-commit ${SCRIPTS_DIR}
+RUN cd ${SCRIPTS_DIR} && \
+        sed -i \
+        -e "s@\${SCRIPTS_DIR}@${SCRIPTS_DIR}@g" \
+        pre-commit
 
-ADD prepare_terrama2_base.sh ${SCRIPTS_DIR}
-RUN cd ${SCRIPTS_DIR} && cat prepare_terrama2_base.sh | sed -e "s@\${DEPENDENCIES_DIR}@${DEPENDENCIES_DIR}@g" > prepare_terrama2_base_2.sh && \
-    cat prepare_terrama2_base_2.sh | sed -e "s@\${TERRALIB_DIR}@${TERRALIB_DIR}@g" > prepare_terrama2_base_3.sh && \
-    cat prepare_terrama2_base_3.sh | sed -e "s@\${TERRAMA2_DIR}@${TERRAMA2_DIR}@g" > prepare_terrama2.sh && \
-    rm prepare_terrama2_base.sh prepare_terrama2_base_2.sh prepare_terrama2_base_3.sh -f
+ADD install-3rdparty-linux-ubuntu-16.04.sh ${SCRIPTS_DIR}
+
+ADD prepare_terralib.sh ${SCRIPTS_DIR}
+RUN cd ${SCRIPTS_DIR} && \
+        sed -i \
+        -e "s@\${DEPENDENCIES_DIR}@${DEPENDENCIES_DIR}@g" \
+        -e "s@\${TERRALIB_DIR}@${TERRALIB_DIR}@g" \
+        -e "s@\${SCRIPTS_DIR}@${SCRIPTS_DIR}@g" \
+        prepare_terralib.sh
+
+ADD prepare_terrama2.sh ${SCRIPTS_DIR}
+RUN cd ${SCRIPTS_DIR} && \
+        sed -i \
+        -e "s@\${DEPENDENCIES_DIR}@${DEPENDENCIES_DIR}@g" \
+        -e "s@\${TERRALIB_DIR}@${TERRALIB_DIR}@g" \
+        -e "s@\${TERRAMA2_DIR}@${TERRAMA2_DIR}@g" \
+        -e "s@\${SCRIPTS_DIR}@${SCRIPTS_DIR}@g" \
+        prepare_terrama2.sh
 
 WORKDIR /home/${USER}
 

--- a/docker/dev/clang-tidy-diff.py
+++ b/docker/dev/clang-tidy-diff.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+#
+#===- clang-tidy-diff.py - ClangTidy Diff Checker ------------*- python -*--===#
+#
+#                     The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See LICENSE.TXT for details.
+#
+#===------------------------------------------------------------------------===#
+
+r"""
+ClangTidy Diff Checker
+======================
+
+This script reads input from a unified diff, runs clang-tidy on all changed
+files and outputs clang-tidy warnings in changed lines only. This is useful to
+detect clang-tidy regressions in the lines touched by a specific patch.
+Example usage for git/svn users:
+
+  git diff -U0 HEAD^ | clang-tidy-diff.py -p1
+  svn diff --diff-cmd=diff -x-U0 | \
+      clang-tidy-diff.py -fix -checks=-*,modernize-use-override
+
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+
+def main():
+  parser = argparse.ArgumentParser(description=
+                                   'Run clang-tidy against changed files, and '
+                                   'output diagnostics only for modified '
+                                   'lines.')
+  parser.add_argument('-clang-tidy-binary', metavar='PATH',
+                      default='clang-tidy',
+                      help='path to clang-tidy binary')
+  parser.add_argument('-p', metavar='NUM', default=0,
+                      help='strip the smallest prefix containing P slashes')
+  parser.add_argument('-regex', metavar='PATTERN', default=None,
+                      help='custom pattern selecting file paths to check '
+                      '(case sensitive, overrides -iregex)')
+  parser.add_argument('-iregex', metavar='PATTERN', default=
+                      r'.*\.(cpp|cc|c\+\+|cxx|c|cl|h|hpp|m|mm|inc)',
+                      help='custom pattern selecting file paths to check '
+                      '(case insensitive, overridden by -regex)')
+
+  parser.add_argument('-fix', action='store_true', default=False,
+                      help='apply suggested fixes')
+  parser.add_argument('-checks',
+                      help='checks filter, when not specified, use clang-tidy '
+                      'default',
+                      default='')
+  parser.add_argument('-path', dest='build_path',
+                      help='Path used to read a compile command database.')
+  parser.add_argument('-extra-arg', dest='extra_arg',
+                      action='append', default=[],
+                      help='Additional argument to append to the compiler '
+                      'command line.')
+  parser.add_argument('-extra-arg-before', dest='extra_arg_before',
+                      action='append', default=[],
+                      help='Additional argument to prepend to the compiler '
+                      'command line.')
+  parser.add_argument('-quiet', action='store_true', default=False,
+                      help='Run clang-tidy in quiet mode')
+  clang_tidy_args = []
+  argv = sys.argv[1:]
+  if '--' in argv:
+    clang_tidy_args.extend(argv[argv.index('--')+1:])
+    argv = argv[:argv.index('--')]
+
+  args = parser.parse_args(argv)
+
+  # Extract changed lines for each file.
+  filename = None
+  lines_by_file = {}
+  for line in sys.stdin:
+    match = re.search('^\+\+\+\ \"?(.*?/){%s}([^ \t\n\"]*)' % args.p, line)
+    if match:
+      filename = match.group(2)
+    if filename == None:
+      continue
+
+    if args.regex is not None:
+      if not re.match('^%s$' % args.regex, filename):
+        continue
+    else:
+      if not re.match('^%s$' % args.iregex, filename, re.IGNORECASE):
+        continue
+
+    match = re.search('^@@.*\+(\d+)(,(\d+))?', line)
+    if match:
+      start_line = int(match.group(1))
+      line_count = 1
+      if match.group(3):
+        line_count = int(match.group(3))
+      if line_count == 0:
+        continue
+      end_line = start_line + line_count - 1;
+      lines_by_file.setdefault(filename, []).append([start_line, end_line])
+
+  if len(lines_by_file) == 0:
+    print("No relevant changes found.")
+    sys.exit(0)
+
+  line_filter_json = json.dumps(
+    [{"name" : name, "lines" : lines_by_file[name]} for name in lines_by_file],
+    separators = (',', ':'))
+
+  quote = "";
+  if sys.platform == 'win32':
+    line_filter_json=re.sub(r'"', r'"""', line_filter_json)
+  else:
+    quote = "'";
+
+  # Run clang-tidy on files containing changes.
+  command = [args.clang_tidy_binary]
+  command.append('-line-filter=' + quote + line_filter_json + quote)
+  if args.fix:
+    command.append('-fix')
+  if args.checks != '':
+    command.append('-checks=' + quote + args.checks + quote)
+  if args.quiet:
+    command.append('-quiet')
+  if args.build_path is not None:
+    command.append('-p=%s' % args.build_path)
+  command.extend(lines_by_file.keys())
+  for arg in args.extra_arg:
+      command.append('-extra-arg=%s' % arg)
+  for arg in args.extra_arg_before:
+      command.append('-extra-arg-before=%s' % arg)
+  command.extend(clang_tidy_args)
+
+  sys.exit(subprocess.call(' '.join(command), shell=True))
+
+if __name__ == '__main__':
+  main()

--- a/docker/dev/pre-commit
+++ b/docker/dev/pre-commit
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Usage: add this file to your project's .git/hooks directory. Rename it to
+# just 'pre-commit'.
+# Now, when you change some files in repository and try to commit these
+# changes, git will run this script right before commit. Cppcheck will scan
+# changed/new files in repository. If it finds some issues, script returns with
+# exit code 1, rejecting commit. Otherwise, script returns 0, and you can
+# actually commit your changes.
+#
+# Example:
+# $ cat hello.c
+# int main() {
+#    int *s = malloc(10);
+# }
+# $ git add hello.c
+# $ git commit
+# Checking hello.c...
+# [hello.c:3]: (error) Memory leak: s
+# [hello.c:2]: (error) The allocated size 10 is not a multiple of the underlying type's size.
+#
+# $ vim hello.c
+# $ cat hello.c
+# int main() {
+# }
+# $ git add hello.c
+# $ git commit
+# Checking hello.c...
+# $
+
+function valid()
+{
+  if [ $1 -ne 0 ]; then
+    exit $1
+  fi
+}
+
+checks=-*,modernize-use-nullptr,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-override,misc-unused-parameters,readability-redundant-string-cstr,readability-redundant-string-init,readability-redundant-member-init,modernize-use-default-member-init
+
+# We should pass only added or modified C/C++ source files to cppcheck.
+changed_files=$(git diff --cached --name-only | grep -E '.*\.(c|cpp|cc|cxx)$')
+
+if [ -n "$changed_files" ]; then
+	cppcheck --error-exitcode=1 --quiet ${changed_files}
+	valid $?
+
+	clang_parse=$(git diff -U0 HEAD^ | ${SCRIPTS_DIR}/clang-tidy-diff.py -p1 -quiet -checks=${checks} -extra-arg-before=-xc++ -extra-arg-before=-std=c++11 -- -warnings-as-errors=* -header-filter=.* 2> /dev/null)
+	echo ${clang_parse} | test $(grep -E "(warning|error)" -c) -eq 0
+	if [ $? -ne 0 ]; then
+		>&2 echo ${clang_parse}
+    exit 1
+  fi
+fi

--- a/docker/dev/prepare_terralib.sh
+++ b/docker/dev/prepare_terralib.sh
@@ -33,6 +33,9 @@ sudo apt-get update
   git status
   if [[ $? -ne 0 ]]; then
     GIT_SSL_NO_VERIFY=true git clone -b release-5.3 https://gitlab.dpi.inpe.br/terralib/terralib.git .
+
+    cd .git/hooks
+    cp ${SCRIPTS_DIR}/pre-commit .
   fi
 )
 

--- a/docker/dev/prepare_terrama2.sh
+++ b/docker/dev/prepare_terrama2.sh
@@ -47,6 +47,9 @@ sudo apt-get update
   git status
   if [[ $? -ne 0 ]]; then
     git clone https://github.com/TerraMA2/terrama2.git .
+
+    cd .git/hooks
+    cp ${SCRIPTS_DIR}/pre-commit .
   fi
 )
 


### PR DESCRIPTION
## Description:

Update dev-docker with clang-tidy-diff (includes fix for extra commands)
and pre-commit script for terralib and terrama2 repositories

## Reviewers:

@raphaelrpl 

**Type:**

- [ ] New feature
- [x] Enhancement
- [ ] Bug

**Platform:**

- [x] Linux
- [ ] Mac
- [ ] Windows

<details>
<summary><b>Changelog:<b/></summary>

*Enhancement:*
* Use clang-tidy-diff and pre-commit script in docker dev

</details>
