### PR TITLE
Fix view permission on webmonitor (temporary)

### DIFF
--- a/webmonitor/controllers/LoginController.js
+++ b/webmonitor/controllers/LoginController.js
@@ -43,7 +43,8 @@ var LoginController = function(app) {
 
           return response.json({
             error: null,
-            username: user.name
+            username: user.name,
+            token: user.token
           });
         });
       }

--- a/webmonitor/gruntfile.js
+++ b/webmonitor/gruntfile.js
@@ -8,8 +8,15 @@ module.exports = function(grunt) {
       TerraMA2WebMonitor: {
         options: {
           baseUrl: "public/javascripts",
-          out: "public/dist/TerraMA2WebMonitor.min.js",
-          preserveLicenseComments: false,
+          optimize: "none",
+          out: function(text, sourceMapText) {
+            var UglifyJS = require('uglify-es');
+            uglified = UglifyJS.minify(text, { sourceMap: { content: sourceMapText, url: "/dist/TerraMA2WebMonitor.min.js" } });
+
+            grunt.file.write("public/dist/TerraMA2WebMonitor.min.js", uglified.code);
+            grunt.file.write("public/dist/TerraMA2WebMonitor.min.js.map", uglified.map);
+          },
+          generateSourceMaps: true,
           paths: {
             TerraMA2WebComponents: "../../../webcomponents/dist/TerraMA2WebComponents.min"
           },

--- a/webmonitor/package-lock.json
+++ b/webmonitor/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "TerraMA2-webmonitor",
-  "version": "4.0.5-release",
+  "version": "4.0.7-release",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4590,6 +4590,30 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "uglify-es": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+      "dev": true,
+      "requires": {
+        "commander": "2.13.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/webmonitor/package.json
+++ b/webmonitor/package.json
@@ -46,6 +46,7 @@
     "grunt-contrib-watch": "^1.0.0",
     "grunt-jsdoc": "^2.1.0",
     "jsdoc": "^3.4.0",
-    "requirejs": "^2.2.0"
+    "requirejs": "^2.2.0",
+    "uglify-es": "^3.3.9"
   }
 }

--- a/webmonitor/public/javascripts/TerraMA2WebMonitor.js
+++ b/webmonitor/public/javascripts/TerraMA2WebMonitor.js
@@ -264,7 +264,7 @@ define(
         Utils.getSocket().emit('retrieveRemovedViews', { clientId: Utils.getWebAppSocket().id, views: viewsToSend });
       });
 
-      Utils.getWebAppSocket().on('viewReceived', function() {
+      Utils.getWebAppSocket().on('viewReceived', async function() {
         var allLayers = Layers.getAllLayers();
         var viewsToSend = {};
 
@@ -273,7 +273,7 @@ define(
 
         let flag = false;
         try {
-          flag = Utils.isAuthenticated();
+          flag = await Utils.isAuthenticated();
         } catch (err) {
           console.warn("Error checking authentication", err);
         }

--- a/webmonitor/public/javascripts/TerraMA2WebMonitor.js
+++ b/webmonitor/public/javascripts/TerraMA2WebMonitor.js
@@ -112,7 +112,7 @@ define(
           TerraMA2WebComponents.MapDisplay.updateMapSize();
         }, 100);
 
-        $(".sidebar-menu").height((memberWindowHeight - 195) + "px");        
+        $(".sidebar-menu").height((memberWindowHeight - 195) + "px");
       });
 
       $('#close-alert').on('click', function() {
@@ -880,7 +880,7 @@ define(
       loadLayout();
       $("#osm input").trigger("click");
 
-      Utils.getSocket().emit('retrieveViews', { clientId: Utils.getWebAppSocket().id, initialRequest: true });
+      Utils.getSocket().emit('retrieveViews', { clientId: Utils.getWebAppSocket().id, initialRequest: true, token: Utils.getToken() });
     };
 
     return {

--- a/webmonitor/public/javascripts/TerraMA2WebMonitor.js
+++ b/webmonitor/public/javascripts/TerraMA2WebMonitor.js
@@ -271,7 +271,14 @@ define(
         for(var i = 0, allLayersLength = allLayers.length; i < allLayersLength; i++)
           viewsToSend[allLayers[i].id] = allLayers[i].private;
 
-        Utils.getSocket().emit('retrieveViews', { clientId: Utils.getWebAppSocket().id, views: viewsToSend });
+        let flag = false;
+        try {
+          flag = Utils.isAuthenticated();
+        } catch (err) {
+          console.warn("Error checking authentication", err);
+        }
+
+        Utils.getSocket().emit('retrieveViews', { clientId: Utils.getWebAppSocket().id, views: viewsToSend, token: flag ? Utils.getToken(): "" });
       });
 
       Utils.getWebAppSocket().on('projectReceived', function(project) {
@@ -880,7 +887,11 @@ define(
       loadLayout();
       $("#osm input").trigger("click");
 
-      Utils.getSocket().emit('retrieveViews', { clientId: Utils.getWebAppSocket().id, initialRequest: true, token: Utils.getToken() });
+      Utils.isAuthenticated()
+        .then(flag => {
+          Utils.getSocket().emit('retrieveViews', { clientId: Utils.getWebAppSocket().id, initialRequest: true, token: flag ? Utils.getToken() : "" });
+        })
+        .catch(error => console.error(error));
     };
 
     return {

--- a/webmonitor/public/javascripts/components/Login.js
+++ b/webmonitor/public/javascripts/components/Login.js
@@ -31,12 +31,13 @@ define(
           $("#user-div").removeClass("hidden");
 
         State.verifyState();
-        Utils.getSocket().emit('retrieveViews', { clientId: Utils.getWebAppSocket().id, onlyPrivate: true });
+        Utils.getSocket().emit('retrieveViews', { clientId: Utils.getWebAppSocket().id, onlyPrivate: true, token: Utils.getToken() });
       }
     };
 
     var signout = function() {
       Layers.removePrivateLayers();
+      Utils.clearSession();
 
       if(!$('#authentication-div').hasClass('hidden'))
         $('#authentication-div').addClass('hidden');
@@ -62,6 +63,7 @@ define(
           username: $("#username").val(),
           password: $("#password").val()
         }, function(data) {
+          Utils.setToken(data.token);
           signin(data.error, data.username);
         });
       });

--- a/webmonitor/public/javascripts/components/State.js
+++ b/webmonitor/public/javascripts/components/State.js
@@ -121,7 +121,7 @@ define(
 
       for(var i = 0, layersLength = newOrder.length; i < layersLength; i++) {
         var layer = Layers.getLayerById(newOrder[i].id);
-        
+
         if(layer !== null && $("#terrama2-sortlayers > ul > #" + layer.htmlId).length > 0) {
           TerraMA2WebComponents.MapDisplay.alterLayerIndex($("#terrama2-sortlayers > ul > #" + layer.htmlId).attr('data-parentid'), (sortableLength - $("#terrama2-sortlayers > ul > #" + layer.htmlId).index()), sortableLength);
           $("#terrama2-sortlayers > ul").insertAt(0, $("#terrama2-sortlayers > ul > #" + layer.htmlId).detach());
@@ -138,7 +138,7 @@ define(
     };
 
     var verifyState = function() {
-      Utils.getSocket().emit('getState', { verifyState: true });
+      Utils.getSocket().emit('getState', { verifyState: true, token: Utils.getToken() });
     };
 
     var loadSocketsListeners = function() {

--- a/webmonitor/public/javascripts/components/Utils.js
+++ b/webmonitor/public/javascripts/components/Utils.js
@@ -39,6 +39,20 @@ define(
       sessionStorage.removeItem("token");
     };
 
+    /**
+     * Check if there a active user session on remote server.
+     *
+     * @returns Promise<boolean>
+     */
+    const isAuthenticated = () => {
+      return new Promise((resolve, reject) => {
+        $.post(BASE_URL + "check-authentication", function(data) {
+          return resolve(data.isAuthenticated);
+        })
+        .fail(() => reject(new Error("Could not check authentication. Please refresh page (F5).")));
+      });
+    };
+
     var getWebAppSocket = function() {
       return memberWebAppSocket;
     };
@@ -144,7 +158,8 @@ define(
       orderByProperty: orderByProperty,
       setToken,
       getToken,
-      clearSession
+      clearSession,
+      isAuthenticated
     };
   }
 );

--- a/webmonitor/public/javascripts/components/Utils.js
+++ b/webmonitor/public/javascripts/components/Utils.js
@@ -16,6 +16,29 @@ define(
       return memberSocket;
     };
 
+    /**
+     * Retrieves current token of browser cache
+     */
+    const getToken = () => {
+      return sessionStorage.getItem("token");
+    };
+
+    /**
+     * Used to set current session token in browser cache
+     *
+     * @param {string} token
+     */
+    const setToken = (token) => {
+      sessionStorage.setItem("token", token);
+    };
+
+    /**
+     * Clear current browser cache
+     */
+    const clearSession = () => {
+      sessionStorage.removeItem("token");
+    };
+
     var getWebAppSocket = function() {
       return memberWebAppSocket;
     };
@@ -118,7 +141,10 @@ define(
       changeLanguage: changeLanguage,
       getSocket: getSocket,
       getWebAppSocket: getWebAppSocket,
-      orderByProperty: orderByProperty
+      orderByProperty: orderByProperty,
+      setToken,
+      getToken,
+      clearSession
     };
   }
 );

--- a/webmonitor/sockets/ViewsHandler.js
+++ b/webmonitor/sockets/ViewsHandler.js
@@ -35,7 +35,7 @@ var ViewsHandlers = function(io) {
         url: memberConfig.webadmin.protocol + memberConfig.webadmin.host + ":" + memberConfig.webadmin.port + memberConfig.webadmin.basePath + action,
         form: {
           clientId: json.clientId,
-          userToken: userToken.getToken(),
+          userToken: json.token,
           initialRequest: json.initialRequest,
           onlyPrivate: json.onlyPrivate,
           views: (json.views ? json.views : null)


### PR DESCRIPTION
## Description:

A private view can be accessed by a user without authentication. It seems related token handling on webmonitor.
The temporary solution is to keep authority token in browser session whenever user tries to login, keeping the consistency with back-end. But is should be re-factored in the future to adopt the architecture of OAuth2 tokens for security and scalable environments.

## Reviewers:

@janosimas 

**Type:**

- [ ] New feature
- [ ] Enhancement
- [x] Bug

**Platform:**

- [x] Linux
- [ ] Mac
- [ ] Windows

**Ticket:**
- [x]  - Fix view permission on Webmonitor [1494](https://trac.dpi.inpe.br/terrama2/ticket/1494)

<details>
<summary><b>Changelog:<b/></summary>

*Bug fix:*
* Fix view permission on Webmonitor

</details>
