### PR TITLE
TerraMA2 regex expression

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 # New Features:
 - Allow user to disable a project.
+- Allow regex expressions in the masks.
 
 # Enhancements:
 

--- a/src/terrama2/core/utility/FilterUtils.cpp
+++ b/src/terrama2/core/utility/FilterUtils.cpp
@@ -41,6 +41,7 @@
 #include <string>
 #include <QString>
 #include <QObject>
+#include <QRegExp>
 
 // TODO: This method is being call for every check of the mask, this should only be called once to avoid a costy operation.
 std::string terrama2::core::terramaMask2Regex(const std::string& mask)

--- a/src/terrama2/core/utility/FilterUtils.cpp
+++ b/src/terrama2/core/utility/FilterUtils.cpp
@@ -44,47 +44,62 @@
 
 std::string terrama2::core::terramaMask2Regex(const std::string& mask)
 {
-  QString m(mask.c_str());
+  auto temp = QString::fromStdString(mask);
+  auto list = temp.split(QRegExp("\\%\\(|\\)\\%"), QString::SkipEmptyParts);
+  std::function<bool(int)> isRegex;
+  if(temp.startsWith("%("))
+    isRegex = [](int i){ return i%2 == 0; };
+  else
+    isRegex = [](int i){ return i%2 != 0; };
 
-  // escape regex metacharacters
-  m.replace("+", "\\+");
-  m.replace("(", "\\(");
-  m.replace(")", "\\)");
-  m.replace("[", "\\[");
-  m.replace("]", "\\]");
-  m.replace("{", "\\{");
-  m.replace("}", "\\}");
-  m.replace("^", "\\^");
-  m.replace("$", "\\$");
-  m.replace("&", "\\&");
-  m.replace("|", "\\|");
-  m.replace("?", "\\?");
-  m.replace(".", "\\.");
+  for(int i = 0; i < list.size(); ++i)
+  {
+    auto& m = list[i];
+    if(isRegex(i))
+    {
+      m = "("+m+")";
+      continue;
+    }
 
-  /*
-    YYYY  year with 4 digits        [0-9]{4}
-    YY    year with 2 digits        [0-9]{2}
-    MM    month with 2 digits       0[1-9]|1[012]
-    DD    day with 2 digits         0[1-9]|[12][0-9]|3[01]
-    hh    hout with 2 digits        [0-1][0-9]|2[0-4]
-    mm    minutes with 2 digits     [0-5][0-9]
-    ss    seconds with 2 digits     [0-5][0-9]
-     *    any character, any times  .*
-    */
+    // escape regex metacharacters
+    m.replace("+", "\\+");
+    m.replace("(", "\\(");
+    m.replace(")", "\\)");
+    m.replace("[", "\\[");
+    m.replace("]", "\\]");
+    m.replace("{", "\\{");
+    m.replace("}", "\\}");
+    m.replace("^", "\\^");
+    m.replace("$", "\\$");
+    m.replace("&", "\\&");
+    m.replace("|", "\\|");
+    m.replace("?", "\\?");
+    m.replace(".", "\\.");
 
-  m.replace("%YYYY", "(?<YEAR>[0-9]{4})");
-  m.replace("%YY", "(?<YEAR2DIGITS>[0-9]{2})");
-  m.replace("%MM", "(?<MONTH>0[1-9]|1[012])");
-  m.replace("%DD", "(?<DAY>0[1-9]|[12][0-9]|3[01])");
-  m.replace("%hh", "(?<HOUR>[0-1][0-9]|2[0-4])");
-  m.replace("%mm", "(?<MINUTES>[0-5][0-9])");
-  m.replace("%ss", "(?<SECONDS>[0-5][0-9])");
-  m.replace("*", ".*");
+    /*
+      YYYY  year with 4 digits        [0-9]{4}
+      YY    year with 2 digits        [0-9]{2}
+      MM    month with 2 digits       0[1-9]|1[012]
+      DD    day with 2 digits         0[1-9]|[12][0-9]|3[01]
+      hh    hout with 2 digits        [0-1][0-9]|2[0-4]
+      mm    minutes with 2 digits     [0-5][0-9]
+      ss    seconds with 2 digits     [0-5][0-9]
+      *    any character, any times  .*
+      */
 
-  // add a extension validation in case of the name has it
-  m += "(?<EXTENSIONS>((\\.[^.]+)+\\.(gz|zip|rar|7z|tar)|\\.[^.]+))?";
+    m.replace("%YYYY", "(?<YEAR>[0-9]{4})");
+    m.replace("%YY", "(?<YEAR2DIGITS>[0-9]{2})");
+    m.replace("%MM", "(?<MONTH>0[1-9]|1[012])");
+    m.replace("%DD", "(?<DAY>0[1-9]|[12][0-9]|3[01])");
+    m.replace("%hh", "(?<HOUR>[0-1][0-9]|2[0-4])");
+    m.replace("%mm", "(?<MINUTES>[0-5][0-9])");
+    m.replace("%ss", "(?<SECONDS>[0-5][0-9])");
+    m.replace("*", ".*");
+    // add a extension validation in case of the name has it
+    m += "(?<EXTENSIONS>((\\.[^.]+)+\\.(gz|zip|rar|7z|tar)|\\.[^.]+))?";
+  }
 
-  return m.toStdString();
+  return list.join("").toStdString();
 }
 
 std::shared_ptr<te::dt::TimeInstantTZ> terrama2::core::getFileTimestamp(const std::string& mask,

--- a/src/terrama2/core/utility/FilterUtils.cpp
+++ b/src/terrama2/core/utility/FilterUtils.cpp
@@ -42,6 +42,7 @@
 #include <QString>
 #include <QObject>
 
+// TODO: This method is being call for every check of the mask, this should only be called once to avoid a costy operation.
 std::string terrama2::core::terramaMask2Regex(const std::string& mask)
 {
   auto temp = QString::fromStdString(mask);

--- a/src/terrama2/core/utility/FilterUtils.cpp
+++ b/src/terrama2/core/utility/FilterUtils.cpp
@@ -42,6 +42,7 @@
 #include <QString>
 #include <QObject>
 #include <QRegExp>
+#include <QStringList>
 
 // TODO: This method is being call for every check of the mask, this should only be called once to avoid a costy operation.
 std::string terrama2::core::terramaMask2Regex(const std::string& mask)

--- a/src/terrama2/core/utility/FilterUtils.hpp
+++ b/src/terrama2/core/utility/FilterUtils.hpp
@@ -96,7 +96,30 @@ namespace terrama2
     */
     TMCOREEXPORT bool isValidDatedMask(const std::string& mask);
 
-    //! Convert a TerraMA2 mask to a regular expression
+    /**
+     * @brief Convert a TerraMA2 mask to a regular expression
+     * 
+     * This function will replace TerraMA2 special expressions form Regex expressions,
+     * unless the TerraMA2 regex expression is used every special regex character is scaped.
+     * 
+     * TerraMA2 date expression:
+     *  - %YYYY - Year with four numbers
+     *  - %YY - Year with two numbers
+     *  - %MM - Month with two numbers
+     *  - %DD - Day of the month with two numbers
+     * 
+     * TerraMA2 time expression:
+     *  - %hh - Hour with two numbers
+     *  - %mm - Minutes with two numbers
+     *  - %ss - Seconds with two numbers
+     * 
+     * TerraMA2 general expressions:
+     *  - * - Wildcard character, will match any number of characters
+     *  - %( )% - Regex expression, allow the use of a regex inside the paranteses
+     * 
+     * @param mask TerraMA2 style mask
+     * @return Regex style mask 
+     */
     TMCOREEXPORT std::string terramaMask2Regex(const std::string& mask);
   } // end namespace core
 }   // end namespace terrama2

--- a/webapp/public/javascripts/angular/data-series/services.js
+++ b/webapp/public/javascripts/angular/data-series/services.js
@@ -195,11 +195,22 @@ define([
                     if(
                       value.substr(i, 5) === "%YYYY" ||
                       value.substr(i, 3) === "%YY" || value.substr(i, 3) === "%MM" || value.substr(i, 3) === "%DD" ||
-                      value.substr(i, 3) === "%hh" || value.substr(i, 3) === "%mm" || value.substr(i, 3) === "%ss"
+                      value.substr(i, 3) === "%hh" || value.substr(i, 3) === "%mm" || value.substr(i, 3) === "%ss" ||
+                      value.substr(i, 2) === "%("
                     )
                       continue;
   
                     return false;
+                  }
+
+                  if(value[i] == "(" && i > 0 && value[i-1] === "%")
+                  {
+                    let j = value.indexOf(")%", i);
+                    if(j === -1)
+                      return false;
+                    
+                    i = j+1;
+                    continue;
                   }
   
                   if(value[i] === "*" || value[i] === "%" || value[i] === "." || value[i] === "-" || value[i] === "_" || value[i] === "/")


### PR DESCRIPTION
## Description:

Create a new tag for regex in TerraMA2 masks.
Regex should be enclosed by %( and )%.

## Reviewers:

@raphaelrpl 

**Type:**

- [x] New feature
- [ ] Enhancement
- [ ] Bug

**Platform:**

- [x] Linux
- [x] Mac
- [x] Windows

<details>
<summary><b>Changelog:<b/></summary>

*New feature:*
- Allow regex in the masks.

</details>
