### PR TITLE
Fix project identifier in collector

### DIFF
--- a/webapp/models/Collector.js
+++ b/webapp/models/Collector.js
@@ -18,6 +18,49 @@ module.exports = function(sequelize, DataTypes) {
       timestamps: false,
 
       classMethods: {
+        registerHooks: (models) => {
+          /**
+           * Adds a project identifier to the Collector instance object
+           *
+           * Executes after ORM Sequelize performs Query Operation
+           * @param {Collector|Collector[]} result Result set
+           */
+          function afterFind(result/*, options*/) {
+            if (result instanceof Array) {
+              result.map(collector => collector.project_id = collector.dataValues.project_id = collector.DataSery.project_id);
+            } else {
+              result.project_id = result.dataValues.project_id = result.DataSery.project_id;
+            }
+          }
+
+          /**
+           * Adds a include model in query filter to retrieve DataSeries object.
+           * Executes before Sequelize performs Query Operation.
+           *
+           * @param {*} options A object containing query filter parameters
+           */
+          function beforeFind(options) {
+            let includeOptions = options.include || [];
+
+            for(let modelObject of includeOptions) {
+              // When a data series model is already included, just return query set
+              if (modelObject.model.$schema === models.DataSeries.$schema &&
+                  modelObject.model.tableName === models.DataSeries.tableName) {
+                return;
+              }
+            }
+
+            // Include the model DataSeries to retrieve DataSeries Object
+            includeOptions.push({ model: models.DataSeries });
+
+            // Set include options to original object sequelize filter
+            options.include = includeOptions;
+          }
+
+          Collector.hook("beforeFind", beforeFind);
+          Collector.hook("afterFind", afterFind);
+        },
+
         associate: function(models) {
           Collector.hasOne(models.Filter, {
             foreignKey: {

--- a/webapp/models/index.js
+++ b/webapp/models/index.js
@@ -3,6 +3,8 @@ var db = {};
 var path = require("path");
 var Sequelize = require("sequelize");
 
+const isFunction = require("./../core/Utils").isFunction;
+
 
 function load(sequelizeObject) {
   fs.readdirSync(__dirname).filter(function(file) {
@@ -15,6 +17,10 @@ function load(sequelizeObject) {
   Object.keys(db).forEach(function(modelName) {
     if ("associate" in db[modelName]) {
       db[modelName].associate(db);
+
+      // Register Hooks if there is
+      if (isFunction(db[modelName].registerHooks))
+        db[modelName].registerHooks(db)
     }
   });
 


### PR DESCRIPTION
## Description:

When user performs activate/deactivate a data series with collector, the project id is not set and the terrama2 c++ service stuck due JSON is not valid.
The solution is to customize *beforeFind* and *afterFind* hooks of ORM to ensure that **project_id** is always set.

## Reviewers:

@janosimas

**Type:**

- [ ] New feature
- [x] Enhancement
- [x] Bug

**Platform:**

- [x] Linux
- [x] Mac
- [x] Windows

**Ticket:**
- [x] Fix project idenrifier in collector - [164](http://datainfo.dpi.inpe.br/ticket/164)

<details>
<summary><b>Changelog:<b/></summary>

*Bug fix:*
* Fix project identifier in collector

</details>
