### PR TITLE
Disable swipe button to activate/deactivate projects (temporary)

### DIFF
--- a/webapp/public/javascripts/angular/projects/controllers/list.js
+++ b/webapp/public/javascripts/angular/projects/controllers/list.js
@@ -573,6 +573,10 @@ define(function() {
       $scope.interpolators = {};
 
       response.data.map(function(project, index) {
+        // TODO: Review how to handle swipe
+        // This directive disables swipe button visualization
+        project.active = null;
+
         if($scope.projectsCheckboxes[project.id] == undefined)
           $scope.projectsCheckboxes[project.id] = {
             fileName: project.name,


### PR DESCRIPTION
## Description:

The swipe button of Project List not working. It seems like not implemented yet. 

## Reviewers:

@janosimas 

**Type:**

- [ ] New feature
- [ ] Enhancement
- [x] Bug

**Platform:**

- [x] Web
- [x] Linux
- [x] Mac
- [x] Windows

<details>
<summary><b>Changelog:<b/></summary>

*Bug fix:*
* Disable swipe button to activate/deactivate project and own dependencies 

</details>
