### PR TITLE
Up Python operator for Summarization and patch to wrap Database initialization

### DIFF
--- a/build/cmake/terrama2_analysis_core/CMakeLists.txt
+++ b/build/cmake/terrama2_analysis_core/CMakeLists.txt
@@ -60,6 +60,10 @@ file(GLOB TERRAMA2_DCP_ZONAL_INFLUENCE_HDR_FILES ${TERRAMA2_ABSOLUTE_ROOT_DIR}/s
 file(GLOB TERRAMA2_OCCURRENCE_ZONAL_SRC_FILES ${TERRAMA2_ABSOLUTE_ROOT_DIR}/src/terrama2/services/analysis/core/occurrence/zonal/*.cpp)
 file(GLOB TERRAMA2_OCCURRENCE_ZONAL_HDR_FILES ${TERRAMA2_ABSOLUTE_ROOT_DIR}/src/terrama2/services/analysis/core/occurrence/zonal/*.hpp)
 
+#
+file(GLOB TERRAMA2_OCCURRENCE_SRC_FILES ${TERRAMA2_ABSOLUTE_ROOT_DIR}/src/terrama2/services/analysis/core/occurrence/*.cpp)
+file(GLOB TERRAMA2_OCCURRENCE_HDR_FILES ${TERRAMA2_ABSOLUTE_ROOT_DIR}/src/terrama2/services/analysis/core/occurrence/*.hpp)
+
 file(GLOB TERRAMA2_OCCURRENCE_ZONAL_AGRREGATION_SRC_FILES ${TERRAMA2_ABSOLUTE_ROOT_DIR}/src/terrama2/services/analysis/core/occurrence/zonal/aggregation/*.cpp)
 file(GLOB TERRAMA2_OCCURRENCE_ZONAL_AGGREGATION_HDR_FILES ${TERRAMA2_ABSOLUTE_ROOT_DIR}/src/terrama2/services/analysis/core/occurrence/zonal/aggregation/*.hpp)
 
@@ -132,6 +136,8 @@ source_group("Header Files\\dcp\\zonal\\history\\interval"  FILES ${TERRAMA2_DCP
 source_group("Source Files\\dcp\\zonal\\influence"  FILES ${TERRAMA2_DCP_ZONAL_INFLUENCE_SRC_FILES})
 source_group("Header Files\\dcp\\zonal\\influence"  FILES ${TERRAMA2_DCP_ZONAL_INFLUENCE_HDR_FILES})
 
+source_group("Source Files\\occurrence"  FILES ${TERRAMA2_OCCURRENCE_SRC_FILES})
+source_group("Header Files\\occurrence"  FILES ${TERRAMA2_OCCURRENCE_HDR_FILES})
 source_group("Source Files\\occurrence\\zonal"  FILES ${TERRAMA2_OCCURRENCE_ZONAL_SRC_FILES})
 source_group("Header Files\\occurrence\\zonal"  FILES ${TERRAMA2_OCCURRENCE_ZONAL_HDR_FILES})
 source_group("Source Files\\occurrence\\zonal\\aggregation"  FILES ${TERRAMA2_OCCURRENCE_ZONAL_AGRREGATION_SRC_FILES})
@@ -202,6 +208,9 @@ add_library(terrama2_analysis_core SHARED ${TERRAMA2_SRC_FILES}
                                           ${TERRAMA2_DCP_ZONAL_HISTORY_INTERVAL_HDR_FILES}
                                           ${TERRAMA2_DCP_ZONAL_INFLUENCE_SRC_FILES}
                                           ${TERRAMA2_DCP_ZONAL_INFLUENCE_HDR_FILES}
+
+                                          ${TERRAMA2_OCCURRENCE_SRC_FILES}
+                                          ${TERRAMA2_OCCURRENCE_HDR_FILES}
 
                                           ${TERRAMA2_OCCURRENCE_ZONAL_SRC_FILES}
                                           ${TERRAMA2_OCCURRENCE_ZONAL_HDR_FILES}

--- a/src/terrama2/core/data-model/Filter.hpp
+++ b/src/terrama2/core/data-model/Filter.hpp
@@ -88,6 +88,10 @@ namespace terrama2
       std::string byValue; //! Filter by value expression. Must be a valid sql filter expression.
       DataProviderPtr dataProvider; //! Provider from static data filter.
       DataSeriesPtr dataSeries; //! Static data data series.
+      std::vector<std::string> fields; //! Fields in SELECT clause
+      std::string joinableTable; //! Table to perform inner join. Used when both monitored identifier and additional identififer supplied.
+      std::string monitoredIdentifier; //! Monitored attribute name to execute SQL JOIN while performing operation
+      std::string additionalIdentifier; //! Additional attribute name to execute SQL join while performing operation
 
       //operator bool() const { return dataSetId != 0; }
     };

--- a/src/terrama2/impl/DataAccessorPostGIS.cpp
+++ b/src/terrama2/impl/DataAccessorPostGIS.cpp
@@ -44,6 +44,7 @@
 #include <QObject>
 
 //boost
+#include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/replace.hpp>
 
 std::string terrama2::core::DataAccessorPostGIS::whereConditions(terrama2::core::DataSetPtr dataSet,
@@ -53,7 +54,10 @@ std::string terrama2::core::DataAccessorPostGIS::whereConditions(terrama2::core:
   std::vector<std::string> whereConditions;
   addExtraConditions(dataSet, whereConditions);
   addDateTimeFilter(datetimeColumnName, filter, whereConditions);
+
   addGeometryFilter(dataSet, filter, whereConditions);
+
+  addConstraintFilter(filter, whereConditions);
 
   std::string conditions;
   if(!whereConditions.empty())
@@ -87,6 +91,14 @@ void terrama2::core::DataAccessorPostGIS::addValueFilter(const terrama2::core::F
     else
       conditions = condition;
   }
+}
+
+void terrama2::core::DataAccessorPostGIS::addConstraintFilter(const terrama2::core::Filter& filter, std::vector<std::string>& whereConditions) const
+{
+  if(filter.joinableTable.empty())
+    return;
+
+  whereConditions.push_back(filter.joinableTable + "."+filter.monitoredIdentifier+" = t." + filter.additionalIdentifier);
 }
 
 terrama2::core::DataSetSeries terrama2::core::DataAccessorPostGIS::getSeries(const std::string& uri, const terrama2::core::Filter& filter,
@@ -143,11 +155,28 @@ terrama2::core::DataSetSeries terrama2::core::DataAccessorPostGIS::getSeries(con
   }
 
   std::string query = "SELECT ";
-  query+="* ";
-  query+= "FROM "+tableName+" AS t";
+
+  // When filter fields provided, use it to select. Otherwize, default all
+  if (filter.fields.empty())
+    query+="* ";
+  else
+    query += boost::algorithm::join(filter.fields, ", ");
+
+  query+= " FROM "+tableName+" AS t";
+
+  // Check table join
+  if (!filter.joinableTable.empty())
+  {
+    query += ", " + filter.joinableTable;
+  }
+
   query += whereConditions(dataSet, datetimeColumnName, filter);
 
-  //  TERRAMA2_LOG_DEBUG() << query;
+  // When monitored identifier supplied, add GROUP BY clause
+  if (!filter.monitoredIdentifier.empty())
+    query += " GROUP BY " + filter.joinableTable + "." + filter.monitoredIdentifier;
+
+//  TERRAMA2_LOG_DEBUG() << query;
 
   std::shared_ptr<te::da::DataSet> tempDataSet = transactor->query(query);
 

--- a/src/terrama2/impl/DataAccessorPostGIS.hpp
+++ b/src/terrama2/impl/DataAccessorPostGIS.hpp
@@ -100,6 +100,9 @@ namespace terrama2
         virtual void addValueFilter(const terrama2::core::Filter& filter,
                                     std::string& conditions) const;
 
+        virtual void addConstraintFilter(const terrama2::core::Filter& filter,
+                                         std::vector<std::string>& whereConditions) const;
+
         virtual std::string addLastDatesFilter(terrama2::core::DataSetPtr dataSet,
                                         const std::string datetimeColumnName,
                                         const terrama2::core::Filter& filter,

--- a/src/terrama2/services/analysis/core/MonitoredObjectContext.cpp
+++ b/src/terrama2/services/analysis/core/MonitoredObjectContext.cpp
@@ -311,6 +311,11 @@ void terrama2::services::analysis::core::MonitoredObjectContext::addDataSeries(t
     {
       for(std::size_t i = 0; i < series.syncDataSet->size(); ++i)
       {
+        // This check is necessary to validate if geometry is defined.
+        // Since we are working with summarization, it is not retrieve
+        // a geometry property for performance issues.
+        if (series.syncDataSet->isNull(i, geomPropertyPosition))
+          continue;
 
         auto geom = series.syncDataSet->getGeometry(i, geomPropertyPosition);
         dataSeriesContext->rtree.insert(*geom->getMBR(), i);

--- a/src/terrama2/services/analysis/core/occurrence/Operator.cpp
+++ b/src/terrama2/services/analysis/core/occurrence/Operator.cpp
@@ -1,0 +1,52 @@
+/*
+  Copyright (C) 2007 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of TerraMA2 - a free and open source computational
+  platform for analysis, monitoring, and alert of geo-environmental extremes.
+
+  TerraMA2 is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License,
+  or (at your option) any later version.
+
+  TerraMA2 is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with TerraMA2. See LICENSE. If not, write to
+  TerraMA2 Team at <terrama2-team@dpi.inpe.br>.
+*/
+
+/*!
+  \file terrama2/services/analysis/core/occurrence/Operator.cpp
+
+  \brief Contains implementation of occurrence analysis operators (summarization).
+
+  \author Raphael Willian da Costa
+*/
+
+
+#include "Operator.hpp"
+#include "zonal/Operator.hpp"
+
+int
+terrama2::services::analysis::core::occurrence::count(const std::string& dataSeriesName,
+                                                      const std::string& dateFilter,
+                                                      const std::string& monitoredIdentifier,
+                                                      const std::string& additionalIdentifier,
+                                                      const std::string& restriction)
+{
+  return static_cast<int>(zonal::operatorImpl(StatisticOperation::COUNT,
+                                              dataSeriesName,
+                                              terrama2::services::analysis::core::Buffer(),
+                                              dateFilter,
+                                              "0s",
+                                              terrama2::services::analysis::core::Buffer(),
+                                              "",
+                                              StatisticOperation::INVALID,
+                                              restriction,
+                                              monitoredIdentifier,
+                                              additionalIdentifier));
+}

--- a/src/terrama2/services/analysis/core/occurrence/Operator.hpp
+++ b/src/terrama2/services/analysis/core/occurrence/Operator.hpp
@@ -1,0 +1,75 @@
+/*
+  Copyright (C) 2007 National Institute For Space Research (INPE) - Brazil.
+
+  This file is part of TerraMA2 - a free and open source computational
+  platform for analysis, monitoring, and alert of geo-environmental extremes.
+
+  TerraMA2 is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License,
+  or (at your option) any later version.
+
+  TerraMA2 is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with TerraMA2. See LICENSE. If not, write to
+  TerraMA2 Team at <terrama2-team@dpi.inpe.br>.
+*/
+
+/*!
+  \file terrama2/services/analysis/core/occurrence/Operator.hpp
+
+  \brief Contains occurrence analysis operators (summarization).
+
+  \author Raphael Willian da Costa
+*/
+
+
+#ifndef __TERRAMA2_SERVICES_ANALYSIS_CORE_OCCURRENCE_OPERATOR_HPP__
+#define __TERRAMA2_SERVICES_ANALYSIS_CORE_OCCURRENCE_OPERATOR_HPP__
+
+
+// TerraMA2
+#include "../Config.hpp"
+
+// STL
+#include <string>
+
+namespace terrama2
+{
+  namespace services
+  {
+    namespace analysis
+    {
+      namespace core
+      {
+        namespace occurrence
+        {
+          /*!
+            \brief Calculates the count of occurrences in the monitored object.
+
+            This operation does not use Geometry as filter.
+
+            \param dataSeriesName DataSeries name.
+            \param dateFilter Time filter for the data.
+            \param monitoredIdentifier Monitored Identifier Attribute to join
+            \param additionalIdentifier Additional Indentifiere Attribute to join
+            \param restriction SQL restriction.
+
+            \return The number of occurrences in the monitored object.
+          */
+          TMANALYSISEXPORT int count(const std::string& dataSeriesName,
+                                     const std::string& dateFilter,
+                                     const std::string& monitoredIdentifier,
+                                     const std::string& additionalIdentifier,
+                                     const std::string& restriction= "");
+        }
+      }
+    }
+  }
+}
+
+#endif // __TERRAMA2_SERVICES_ANALYSIS_CORE_OCCURRENCE_OPERATOR_HPP__

--- a/src/terrama2/services/analysis/core/occurrence/zonal/Operator.cpp
+++ b/src/terrama2/services/analysis/core/occurrence/zonal/Operator.cpp
@@ -43,13 +43,15 @@
 #include <terralib/vp/BufferMemory.h>
 #include <terralib/geometry/MultiPolygon.h>
 #include <terralib/geometry/Utils.h>
+#include <terralib/dataaccess/datasource/DataSourceTransactor.h>
 
 double terrama2::services::analysis::core::occurrence::zonal::operatorImpl(terrama2::services::analysis::core::StatisticOperation statisticOperation,
                                                                            const std::string &dataSeriesName, terrama2::services::analysis::core::Buffer buffer,
                                                                            const std::string &dateFilterBegin, const std::string &dateFilterEnd,
                                                                            terrama2::services::analysis::core::Buffer aggregationBuffer, const std::string &attribute,
                                                                            terrama2::services::analysis::core::StatisticOperation aggregationStatisticOperation,
-                                                                           const std::string &restriction)
+                                                                           const std::string &restriction,
+                                                                           const std::string& monitoredIdentifier, const std::string& additionalIdentifier)
 {
 
   OperatorCache cache;
@@ -90,7 +92,6 @@ double terrama2::services::analysis::core::occurrence::zonal::operatorImpl(terra
     if(context->hasError())
       return std::nan("");
 
-
     bool hasData = false;
 
     auto dataManagerPtr = context->getDataManager().lock();
@@ -103,6 +104,7 @@ double terrama2::services::analysis::core::occurrence::zonal::operatorImpl(terra
     AnalysisPtr analysis = context->getAnalysis();
 
     std::shared_ptr<ContextDataSeries> moDsContext = context->getMonitoredObjectContextDataSeries();
+
     if(moDsContext->series.syncDataSet->size() == 0)
     {
       QString errMsg(QObject::tr("Could not recover monitored object data series."));
@@ -110,6 +112,7 @@ double terrama2::services::analysis::core::occurrence::zonal::operatorImpl(terra
     }
 
     auto moGeom = moDsContext->series.syncDataSet->getGeometry(cache.index, moDsContext->geometryPos);
+
     if(!moGeom.get())
     {
       QString errMsg(QObject::tr("Could not recover monitored object geometry."));
@@ -136,8 +139,32 @@ double terrama2::services::analysis::core::occurrence::zonal::operatorImpl(terra
         filter.discardBefore = context->getTimeFromString(dateFilterBegin);
         filter.discardAfter = context->getTimeFromString(dateFilterEnd);
         filter.byValue = restriction;
-        filter.region = geomResult;
 
+        /*
+         * When performing summarization, both modified and additional identifier must be
+         * supplied to skip filter by region.
+         */
+        if (monitoredIdentifier.empty() && additionalIdentifier.empty())
+        {
+          filter.region = geomResult;
+        }
+        else
+        {
+          auto monitoredDataSeries = dataManagerPtr->findDataSeries(moDsContext->series.dataSet->dataSeriesId);
+
+          filter.joinableTable = terrama2::core::getProperty(moDsContext->series.dataSet, monitoredDataSeries, "table_name");
+
+          // Make query fields
+          std::vector<std::string> fields;
+          // Retrieving operation for summarization
+
+          // TODO: Remove (*). Currently is only working with COUNT.
+          fields.push_back(operationAsString(statisticOperation)+ "(*)");
+          fields.push_back(filter.joinableTable + "." + monitoredIdentifier);
+          filter.fields = std::move(fields);
+          filter.monitoredIdentifier = monitoredIdentifier;
+          filter.additionalIdentifier = additionalIdentifier;
+        }
         auto dataSeries = dataManagerPtr->findDataSeries(analysis->id, dataSeriesName);
         context->addDataSeries(dataSeries, filter, true);
 
@@ -152,7 +179,6 @@ double terrama2::services::analysis::core::occurrence::zonal::operatorImpl(terra
             continue;
           }
 
-
           uint32_t countValues = 0;
           std::vector<double> values;
 
@@ -164,103 +190,134 @@ double terrama2::services::analysis::core::occurrence::zonal::operatorImpl(terra
           }
           else
           {
-            // Converts the monitored object to the same srid of the occurrences
-            auto firstOccurrence = syncDs->getGeometry(0, contextDataSeries->geometryPos);
-            geomResult->transform(firstOccurrence->getSRID());
-
-            int attributeType = 0;
-            if(!attribute.empty())
+            /*
+             * Summarization executed only when both monitored identifier and
+             * additional identifier supplied.
+             * In this way, we must just perform count operation over monitored
+             * data series
+             *
+             */
+            if (!monitoredIdentifier.empty() && !additionalIdentifier.empty())
             {
-              auto property = contextDataSeries->series.teDataSetType->getProperty(attribute);
+              // Allocate memory for indexes size
+              values.reserve(syncDs->size());
 
-              // only operation COUNT can be done without attribute.
-              if(!property && statisticOperation != StatisticOperation::COUNT)
+              // Retrieve monitored value. Used in summarization
+              auto monitoredValue = moDsContext->series.syncDataSet->getAsString(cache.index, monitoredIdentifier);
+
+              for(uint32_t i = 0; i < syncDs->size(); ++i)
               {
-                return std::nan("");
-              }
-              attributeType = property->getType();
-            }
+                auto additionalValue = syncDs->getAsString(i, additionalIdentifier);
 
-            if(aggregationStatisticOperation != StatisticOperation::INVALID)
-            {
-              auto bufferDs = createAggregationBuffer(contextDataSeries, aggregationBuffer,
-                                                      aggregationStatisticOperation, attribute);
-
-              if(!bufferDs)
-              {
-                continue;
-              }
-
-              // Allocate memory for dataset size
-              values.reserve(bufferDs->size());
-              for(unsigned int i = 0; i < bufferDs->size(); ++i)
-              {
-                bufferDs->move(i);
-                auto occurrenceGeom = bufferDs->getGeometry(0);
-
-                if(occurrenceGeom->intersects(geomResult.get()))
+                if (monitoredValue == additionalValue)
                 {
-                  ++countValues;
+                  // Count is always first attribute
+                  countValues += syncDs->getInt64(i, 0);
 
-                  try
-                  {
-                    if(!attribute.empty())
-                    {
-                      hasData = true;
-                      // second column contains the value
-                      double value = bufferDs->getDouble(1);
-
-                      if(std::isnan(value))
-                        continue;
-
-                      values.push_back(value);
-                    }
-                  }
-                  catch(...)
-                  {
-                    // In case the dataset doesn't have the specified attribute
-                    continue;
-                  }
+                  values.push_back(0);
                 }
               }
             }
             else
             {
 
-              // Allocate memory for indexes size
-              values.reserve(syncDs->size());
-              for(uint32_t i = 0; i < syncDs->size(); ++i)
+              // Converts the monitored object to the same srid of the occurrences
+              auto firstOccurrence = syncDs->getGeometry(0, contextDataSeries->geometryPos);
+              geomResult->transform(firstOccurrence->getSRID());
+
+              int attributeType = 0;
+              if(!attribute.empty())
               {
-                // Verifies if the occurrence intersects the monitored object
-                auto occurrenceGeom = syncDs->getGeometry(i, contextDataSeries->geometryPos);
+                auto property = contextDataSeries->series.teDataSetType->getProperty(attribute);
 
-                if(occurrenceGeom->intersects(geomResult.get()))
+                // only operation COUNT can be done without attribute.
+                if(!property && statisticOperation != StatisticOperation::COUNT)
                 {
-                  ++countValues;
+                  return std::nan("");
+                }
+                attributeType = property->getType();
+              }
 
-                  try
+              if(aggregationStatisticOperation != StatisticOperation::INVALID)
+              {
+                auto bufferDs = createAggregationBuffer(contextDataSeries, aggregationBuffer,
+                                                        aggregationStatisticOperation, attribute);
+
+                if(!bufferDs)
+                {
+                  continue;
+                }
+
+                // Allocate memory for dataset size
+                values.reserve(bufferDs->size());
+                for(unsigned int i = 0; i < bufferDs->size(); ++i)
+                {
+                  bufferDs->move(i);
+                  auto occurrenceGeom = bufferDs->getGeometry(0);
+
+                  if(occurrenceGeom->intersects(geomResult.get()))
                   {
-                    if(!attribute.empty() && !syncDs->isNull(i, attribute))
+                    ++countValues;
+
+                    try
                     {
-                      hasData = true;
-                      double value = terrama2::services::analysis::core::getValue(syncDs, attribute, i, attributeType);
+                      if(!attribute.empty())
+                      {
+                        hasData = true;
+                        // second column contains the value
+                        double value = bufferDs->getDouble(1);
 
-                      if(std::isnan(value))
-                        continue;
+                        if(std::isnan(value))
+                          continue;
 
-                      values.push_back(value);
+                        values.push_back(value);
+                      }
+                    }
+                    catch(...)
+                    {
+                      // In case the dataset doesn't have the specified attribute
+                      continue;
                     }
                   }
-                  catch(...)
+                }
+              }
+              else
+              {
+                // Allocate memory for indexes size
+                values.reserve(syncDs->size());
+                {
+                  for(uint32_t i = 0; i < syncDs->size(); ++i)
                   {
-                    // In case the dataset doesn't have the specified attribute
-                    continue;
+                    // Verifies if the occurrence intersects the monitored object
+                    auto occurrenceGeom = syncDs->getGeometry(i, contextDataSeries->geometryPos);
+
+                    if(occurrenceGeom->intersects(geomResult.get()))
+                    {
+                      ++countValues;
+
+                      try
+                      {
+                        if(!attribute.empty() && !syncDs->isNull(i, attribute))
+                        {
+                          hasData = true;
+                          double value = terrama2::services::analysis::core::getValue(syncDs, attribute, i, attributeType);
+
+                          if(std::isnan(value))
+                            continue;
+
+                          values.push_back(value);
+                        }
+                      }
+                      catch(...)
+                      {
+                        // In case the dataset doesn't have the specified attribute
+                        continue;
+                      }
+                    }
                   }
                 }
               }
             }
-
-
 
             terrama2::services::analysis::core::calculateStatistics(values, cache);
 
@@ -341,10 +398,10 @@ double terrama2::services::analysis::core::occurrence::zonal::operatorImpl(terra
 }
 
 double terrama2::services::analysis::core::occurrence::zonal::count(const std::string& dataSeriesName,
-    const std::string& dateFilter, Buffer buffer, const std::string& restriction)
+    const std::string& dateFilter, Buffer buffer, const std::string& restriction, const std::string& monitoredIdentifier, const std::string& additionalIdentifier)
 {
   return operatorImpl(StatisticOperation::COUNT, dataSeriesName, buffer, dateFilter, "0s", Buffer(),
-                      "", StatisticOperation::INVALID, restriction);
+                      "", StatisticOperation::INVALID, restriction, monitoredIdentifier, additionalIdentifier);
 }
 
 double terrama2::services::analysis::core::occurrence::zonal::min(const std::string& dataSeriesName,

--- a/src/terrama2/services/analysis/core/occurrence/zonal/Operator.hpp
+++ b/src/terrama2/services/analysis/core/occurrence/zonal/Operator.hpp
@@ -70,7 +70,7 @@ namespace terrama2
                                 const std::string &dateFilterBegin, const std::string &dateFilterEnd,
                                 terrama2::services::analysis::core::Buffer aggregationBuffer, const std::string &attribute,
                                 terrama2::services::analysis::core::StatisticOperation aggregationStatisticOperation,
-                                const std::string &restriction);
+                                const std::string &restriction, const std::string& monitoredIdentifier = "", const std::string& additionalIdentifier = "");
 
             /*!
               \brief Calculates the count of occurrences in the monitored object.
@@ -84,7 +84,7 @@ namespace terrama2
             */
             TMANALYSISEXPORT double count(const std::string& dataSeriesName, const std::string& dateFilter,
                       terrama2::services::analysis::core::Buffer buffer = Buffer(),
-                      const std::string& restriction= "");
+                      const std::string& restriction= "", const std::string& monitoredIdentifier = "", const std::string& additionalIdentifier = "");
 
             /*!
               \brief Calculates the minimum value of the attribute of occurrences in the monitored object area.

--- a/src/terrama2/services/analysis/core/occurrence/zonal/aggregation/Operator.cpp
+++ b/src/terrama2/services/analysis/core/occurrence/zonal/aggregation/Operator.cpp
@@ -37,13 +37,17 @@ int terrama2::services::analysis::core::occurrence::zonal::aggregation::count(co
                                                                        const std::string& dateFilter,
                                                                        Buffer aggregationBuffer,
                                                                        Buffer buffer,
-                                                                       const std::string& restriction)
+                                                                       const std::string& restriction,
+                                                                       const std::string& monitoredIdentifier,
+                                                                       const std::string& additionalIdentifier)
 {
   return (int) terrama2::services::analysis::core::occurrence::zonal::operatorImpl(StatisticOperation::COUNT,
                                                                                    dataSeriesName, buffer, dateFilter,
                                                                                    "0s", aggregationBuffer,
                                                                                    "", StatisticOperation::COUNT,
-                                                                                   restriction);
+                                                                                   restriction,
+                                                                                   monitoredIdentifier,
+                                                                                   additionalIdentifier);
 }
 
 double terrama2::services::analysis::core::occurrence::zonal::aggregation::min(const std::string& dataSeriesName,

--- a/src/terrama2/services/analysis/core/occurrence/zonal/aggregation/Operator.hpp
+++ b/src/terrama2/services/analysis/core/occurrence/zonal/aggregation/Operator.hpp
@@ -53,10 +53,12 @@ namespace terrama2
             namespace aggregation
             {
               TMANALYSISEXPORT int count(const std::string& dataSeriesName,
-                        const std::string& dateFilter,
-                        terrama2::services::analysis::core::Buffer aggregationBuffer,
-                        terrama2::services::analysis::core::Buffer buffer = Buffer(),
-                        const std::string& restriction = "");
+                                         const std::string& dateFilter,
+                                         terrama2::services::analysis::core::Buffer aggregationBuffer,
+                                         terrama2::services::analysis::core::Buffer buffer = Buffer(),
+                                         const std::string& restriction = "",
+                                         const std::string& monitoredIdentifier = "",
+                                         const std::string& additionalIdentifier = "");
 
               /*!
                 \brief Calculates the maximum value of the attribute of occurrences in the monitored object area.

--- a/src/terrama2/services/analysis/core/python/PythonBindingMonitoredObject.cpp
+++ b/src/terrama2/services/analysis/core/python/PythonBindingMonitoredObject.cpp
@@ -4,6 +4,7 @@
 #include "../dcp/zonal/history/Operator.hpp"
 #include "../dcp/zonal/history/interval/Operator.hpp"
 #include "../dcp/zonal/influence/PythonOperator.hpp"
+#include "../occurrence/Operator.hpp"
 #include "../occurrence/zonal/Operator.hpp"
 #include "../occurrence/zonal/interval/Operator.hpp"
 #include "../occurrence/zonal/aggregation/Operator.hpp"
@@ -13,7 +14,7 @@
 #pragma GCC diagnostic ignored "-Wunused-local-typedef"
 
 // // Declaration needed for default parameter restriction
-BOOST_PYTHON_FUNCTION_OVERLOADS(occurrenceCount_overloads, terrama2::services::analysis::core::occurrence::zonal::count, 2, 4)
+BOOST_PYTHON_FUNCTION_OVERLOADS(occurrenceCount_overloads, terrama2::services::analysis::core::occurrence::zonal::count, 2, 6)
 
 BOOST_PYTHON_FUNCTION_OVERLOADS(occurrenceMin_overloads, terrama2::services::analysis::core::occurrence::zonal::min, 3, 5)
 
@@ -28,6 +29,10 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(occurrenceSum_overloads, terrama2::services::ana
 BOOST_PYTHON_FUNCTION_OVERLOADS(occurrenceStandardDeviation_overloads, terrama2::services::analysis::core::occurrence::zonal::standardDeviation, 4, 5)
 
 BOOST_PYTHON_FUNCTION_OVERLOADS(occurrenceVariance_overloads, terrama2::services::analysis::core::occurrence::zonal::variance, 3, 5)
+
+// Occurrence Summary
+
+BOOST_PYTHON_FUNCTION_OVERLOADS(occurrenceSummaryCount_overloads, terrama2::services::analysis::core::occurrence::count, 4, 5)
 
 // Occurence interval
 
@@ -50,7 +55,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(occurrenceIntervalVariance_overloads, terrama2::
 
 // Occurence aggreagation
 
-BOOST_PYTHON_FUNCTION_OVERLOADS(occurrenceAggregationCount_overloads, terrama2::services::analysis::core::occurrence::zonal::aggregation::count, 3, 5)
+BOOST_PYTHON_FUNCTION_OVERLOADS(occurrenceAggregationCount_overloads, terrama2::services::analysis::core::occurrence::zonal::aggregation::count, 3, 7)
 
 BOOST_PYTHON_FUNCTION_OVERLOADS(occurrenceAggregationMin_overloads, terrama2::services::analysis::core::occurrence::zonal::aggregation::min, 5, 7)
 
@@ -96,6 +101,11 @@ void terrama2::services::analysis::core::python::MonitoredObject::registerOccurr
   // set the current scope to the new sub-module
   scope occurrenceScope = occurrenceModule;
 
+  // Export summary
+  def("count", terrama2::services::analysis::core::occurrence::count,
+      occurrenceSummaryCount_overloads(args("dataSeriesName", "dateFilter", "monitoredIdentifier", "additinalIdentifier", "restriction"),
+                                "Count operator for occurrence"));
+
   boost::python::object occurrenceZonalModule(handle<>(borrowed(PyImport_AddModule("terrama2.occurrence.zonal"))));
   import("terrama2.occurrence").attr("zonal") = occurrenceZonalModule;
 
@@ -121,7 +131,6 @@ void terrama2::services::analysis::core::python::MonitoredObject::registerOccurr
   def("variance", terrama2::services::analysis::core::occurrence::zonal::variance,
       occurrenceVariance_overloads(args("dataSeriesName", "attribute", "dateFilter", "buffer", "restriction"),
                                    "Variance operator for occurrence"));
-
 }
 
 
@@ -268,7 +277,7 @@ void terrama2::services::analysis::core::python::MonitoredObject::registerOccurr
   scope occurrenceAggregationScope = occurrenceAggregationModule;
 
   def("count", terrama2::services::analysis::core::occurrence::zonal::aggregation::count,
-      occurrenceAggregationCount_overloads(args("dataSeriesName", "dateFilter", "aggregationBuffer", "buffer", "restriction"),
+      occurrenceAggregationCount_overloads(args("dataSeriesName", "dateFilter", "aggregationBuffer", "buffer", "restriction", "monitoredIdentifier", "additionalIdentifier"),
                                            "Count operator for occurrence aggregation"));
   def("min", terrama2::services::analysis::core::occurrence::zonal::aggregation::min,
       occurrenceAggregationMin_overloads(args("dataSeriesName", "dateFilter", "aggregationBuffer", "buffer", "restriction"), "Minimum operator for occurrence aggregation"));

--- a/src/terrama2/services/analysis/core/utility/Utils.cpp
+++ b/src/terrama2/services/analysis/core/utility/Utils.cpp
@@ -360,3 +360,24 @@ std::pair<size_t, size_t> terrama2::services::analysis::core::getBandInterval(te
 
   return std::make_pair(bandBegin, bandEnd);
 }
+
+std::string terrama2::services::analysis::core::operationAsString(terrama2::services::analysis::core::StatisticOperation op)
+{
+  switch(op)
+  {
+    case StatisticOperation::SUM:
+      return "sum";
+    case StatisticOperation::MEAN:
+      return "avg";
+    case StatisticOperation::MIN:
+      return "min";
+    case StatisticOperation::MAX:
+      return "max";
+    case StatisticOperation::COUNT:
+      return "count";
+    case StatisticOperation::VARIANCE:
+      return "variance";
+    default:
+      return "";
+  }
+}

--- a/src/terrama2/services/analysis/core/utility/Utils.hpp
+++ b/src/terrama2/services/analysis/core/utility/Utils.hpp
@@ -66,6 +66,14 @@ namespace terrama2
         };
 
         /*!
+         * \brief Retrieves a string representation of Statistic Operation to be used as Aggregated function in query statement.
+         *
+         * \param op Statistic operation
+         * \return Statistic operation as string
+         */
+        TMANALYSISEXPORT std::string operationAsString(StatisticOperation op);
+
+        /*!
           \brief Returns a enum with the type of the Analysis based on the given parameter.
 
           \param type Type of the Analysis.

--- a/webapp/public/javascripts/angular/analysis/data/occurrence-operators.json
+++ b/webapp/public/javascripts/angular/analysis/data/occurrence-operators.json
@@ -1,5 +1,15 @@
 [
   {
+    "name": "Summary",
+    "children": [
+      {
+        "name": "Count",
+        "code": "occurrence.count(\"<dynamic_data_occurrence>\", \"<time>\", \"<monitored_identifier>\", \"<additional_identifier>\", [\"<restriction>\"])",
+        "description": "Count number of occurrence. It does not use spatial operator"
+      }
+    ]
+  },
+  {
     "name": "Zonal",
     "children": [
       {


### PR DESCRIPTION
## Description:

This PR up python operator for summarization without spatial intersection. It also adds a patch to wrap Database initialization. It is important to fix wrong schema context

**Type:**

- [ ] New feature
- [x] Enhancement
- [ ] Bug

**Platform:**

- [x] Web
- [x] Linux
- [x] Mac
- [x] Windows

<details>
<summary><b>Changelog:<b/></summary>

*Enhancement:*
* Up Python operator for Summarization and patch to wrap Database initialization

</details>
