### PR TITLE
Correction of ocurrence importations from CVS files

### DIFF
--- a/src/terrama2/impl/DataAccessorCSV.cpp
+++ b/src/terrama2/impl/DataAccessorCSV.cpp
@@ -413,10 +413,12 @@ void terrama2::core::DataAccessorCSV::addGeomProperty(QJsonObject fieldGeomObj, 
 
     // get columns from converted dataset
     auto longRemovePos = converter->getResult()->getPropertyPosition(oldLongProp->getName());
-    auto latRemovePos = converter->getResult()->getPropertyPosition(oldLatProp->getName());
-
-    //remove column from converted dataset
+   //remove column from converted dataset
     converter->remove(longRemovePos);
+
+    // get columns from converted dataset
+    auto latRemovePos = converter->getResult()->getPropertyPosition(oldLatProp->getName());
+    //remove column from converted dataset
     converter->remove(latRemovePos);
   }
   else


### PR DESCRIPTION
## Description:
Error in importing burned and custom occurrence data from CVS file

## Reviewers:

@

**Type:**

- [ ] New feature
- [ ] Enhancement
- [x] Bug

**Platform:**

- [x] Web
- [x] Linux
- [ ] Mac
- [ ] Windows

<details>
<summary><b>Changelog:<b/></summary>

*New feature:*
* Item one
   * Sub item one

*Enhancement:*
* Item one
   * Sub item one

*Bug fix:*
* Item one
   * Sub item one

</details>
The error occurred because the search was done before the remotion. The removal modifies the value of the position of attribute.