### PR TITLE
Include CSV delimiter on semantics Occurrence CSV

### DIFF
--- a/src/terrama2/impl/DataAccessorCSV.cpp
+++ b/src/terrama2/impl/DataAccessorCSV.cpp
@@ -110,6 +110,18 @@ QFileInfo terrama2::core::DataAccessorCSV::filterTxt(QFileInfo& fileInfo, QTempo
   std::string line = "";
   int lineNumber = 1;
 
+  std::string delimiter(",");
+
+  try
+  {
+    // Retrieve Attribute Delimiter from GUI interface
+    // Default: comma (,)
+    delimiter = terrama2::core::getProperty(dataSet, dataSeries_, "delimiter");
+  }
+  catch(...)
+  {
+  }
+
   while(std::getline(file, line))
   {
     if(lineNumber <= header && lineNumber != columnsLine)
@@ -118,7 +130,26 @@ QFileInfo terrama2::core::DataAccessorCSV::filterTxt(QFileInfo& fileInfo, QTempo
       continue;
     }
 
-    outputFile << line << "\n";
+    auto fragments = terrama2::core::splitString(line, *delimiter.c_str());
+
+    if (fragments.size() <= 1)
+    {
+      auto errMsg = QObject::tr("Could parse CSV file '%1' with delimiter %2.").arg(fileInfo.absoluteFilePath()).arg(delimiter.c_str());
+      TERRAMA2_LOG_WARNING() << errMsg;
+      throw terrama2::core::UndefinedTagException() << ErrorDescription(errMsg);
+    }
+
+    std::string csvLine;
+
+    for(const auto& fragment: fragments)
+    {
+      if (!csvLine.empty())
+        csvLine += ",";
+      csvLine += fragment;
+    }
+
+    // Write output CSV with common standard (comma)
+    outputFile << csvLine << "\n";
 
     if(!outputFile)
     {

--- a/src/terrama2/services/collector/core/Service.cpp
+++ b/src/terrama2/services/collector/core/Service.cpp
@@ -208,12 +208,12 @@ void terrama2::services::collector::core::Service::collect(terrama2::core::Execu
       }
       catch(const terrama2::core::DataAccessorException& e)
       {
-        status = CollectorLogger::ProcessLogger::Status::WARNING;
+        status = CollectorLogger::ProcessLogger::Status::ERROR;
         std::string errMsg = boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString();
         TERRAMA2_LOG_INFO() << errMsg;
 
         if(executionPackage.registerId != 0)
-          logger->log(CollectorLogger::MessageType::WARNING_MESSAGE, errMsg, executionPackage.registerId);
+          logger->log(CollectorLogger::MessageType::ERROR_MESSAGE, errMsg, executionPackage.registerId);
       }
       catch(const terrama2::Exception& e)
       {

--- a/src/terrama2/services/collector/core/Service.cpp
+++ b/src/terrama2/services/collector/core/Service.cpp
@@ -206,6 +206,15 @@ void terrama2::services::collector::core::Service::collect(terrama2::core::Execu
         if(executionPackage.registerId != 0)
           logger->log(CollectorLogger::MessageType::WARNING_MESSAGE, errMsg, executionPackage.registerId);
       }
+      catch(const terrama2::core::DataAccessorException& e)
+      {
+        status = CollectorLogger::ProcessLogger::Status::WARNING;
+        std::string errMsg = boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString();
+        TERRAMA2_LOG_INFO() << errMsg;
+
+        if(executionPackage.registerId != 0)
+          logger->log(CollectorLogger::MessageType::WARNING_MESSAGE, errMsg, executionPackage.registerId);
+      }
       catch(const terrama2::Exception& e)
       {
         status = CollectorLogger::ProcessLogger::Status::ERROR;

--- a/webapp/public/javascripts/angular/data-series/components/csvFormat.js
+++ b/webapp/public/javascripts/angular/data-series/components/csvFormat.js
@@ -19,7 +19,7 @@ define([],function(){
    * 
    * @param {any} i18n - TerraMA² Internationalization module
    */
-  function CsvFormatController(i18n, $timeout) {
+  function CsvFormatController($scope, $element, $attrs, i18n) {
     var ctrl = this;
     ctrl.i18n = i18n;
 
@@ -45,16 +45,8 @@ define([],function(){
         ctrl.csvFormatData.fields.splice(idx, 1);
       }
     };
-
-    $timeout(() => {
-      const { csvFormatData } = this;
-
-      if (csvFormatData) {
-        csvFormatData.delimiter = csvFormatData.delimiter || ',';
-      }
-    });
   }
 
-  CsvFormatController.$inject = ['i18n', '$timeout']; 
+  CsvFormatController.$inject = ['$scope', '$element', '$attrs', 'i18n']; 
   return terrama2CsvFormatComponent;
 })

--- a/webapp/public/javascripts/angular/data-series/components/csvFormat.js
+++ b/webapp/public/javascripts/angular/data-series/components/csvFormat.js
@@ -19,7 +19,7 @@ define([],function(){
    * 
    * @param {any} i18n - TerraMA² Internationalization module
    */
-  function CsvFormatController($scope, $element, $attrs, i18n) {
+  function CsvFormatController(i18n, $timeout) {
     var ctrl = this;
     ctrl.i18n = i18n;
 
@@ -45,8 +45,16 @@ define([],function(){
         ctrl.csvFormatData.fields.splice(idx, 1);
       }
     };
+
+    $timeout(() => {
+      const { csvFormatData } = this;
+
+      if (csvFormatData) {
+        csvFormatData.delimiter = csvFormatData.delimiter || ',';
+      }
+    });
   }
 
-  CsvFormatController.$inject = ['$scope', '$element', '$attrs', 'i18n']; 
+  CsvFormatController.$inject = ['i18n', '$timeout']; 
   return terrama2CsvFormatComponent;
 })

--- a/webapp/public/javascripts/angular/data-series/registration.js
+++ b/webapp/public/javascripts/angular/data-series/registration.js
@@ -56,7 +56,7 @@ define([], function() {
       metadata: true,
       type: $scope.isDynamic ? "dynamic" : "static"
     };
-    $scope.csvFormatData = { fields: [{type: "DATETIME"}], convert_all: false};
+    $scope.csvFormatData = { fields: [{type: "DATETIME"}], convert_all: false, delimiter: ',' };
     // defining box
     $scope.cssBoxSolid = {
       boxType: "box-solid"
@@ -500,7 +500,7 @@ define([], function() {
         $scope.semanticsCode = $scope.dataSeries.semantics.code;
 
         if (!$scope.isUpdating){
-          $scope.csvFormatData = { fields: [{type: "DATETIME"}], convert_all: false};
+          $scope.csvFormatData = { fields: [{type: "DATETIME"}], convert_all: false, delimiter: ',' };
           clearStoreForm();
         }
         $scope.custom_format = $scope.dataSeries.semantics.custom_format;
@@ -719,6 +719,7 @@ define([], function() {
                   $scope.csvFormatData.default_type = inputDataSeries.dataSets[i].format.default_type;
                   $scope.csvFormatData.convert_all = (inputDataSeries.dataSets[i].format.convert_all == "true");
                   $scope.csvFormatData.properties_names_line = parseInt(inputDataSeries.dataSets[i].format.properties_names_line);
+                  $scope.csvFormatData.delimiter = inputDataSeries.dataSets[i].format.delimiter;
                 }
               } // end for
 
@@ -751,6 +752,7 @@ define([], function() {
               if(inputDataSeries.data_series_semantics.custom_format) {
                 $scope.csvFormatData.fields = JSON.parse(dataSetFormat.fields)
                 $scope.csvFormatData.header_size = parseInt(dataSetFormat.header_size);
+                $scope.csvFormatData.delimiter = dataSetFormat.delimiter;
                 $scope.csvFormatData.default_type = dataSetFormat.default_type;
                 $scope.csvFormatData.convert_all = (dataSetFormat.convert_all == "true");
                 $scope.csvFormatData.properties_names_line = parseInt(dataSetFormat.properties_names_line);

--- a/webapp/public/javascripts/angular/data-series/templates/csvFormat.html
+++ b/webapp/public/javascripts/angular/data-series/templates/csvFormat.html
@@ -15,6 +15,13 @@
     </div>
   </div>
 
+  <div class="col-md-1 col-sm-2 col-xs-3">
+    <div class="form-group" terrama2-show-errors>
+      <label ng-bind="$ctrl.i18n.__('Delimiter')+':'"></label>
+      <input class="form-control" id="delimiter" name="delimiter" type="text" ng-model="$ctrl.csvFormatData.delimiter" ng-value="','" required>
+    </div>
+  </div>
+
   <div class="col-md-2">
     <div class="form-group">
       <div class="checkbox">

--- a/webapp/public/javascripts/angular/data-series/templates/csvFormat.html
+++ b/webapp/public/javascripts/angular/data-series/templates/csvFormat.html
@@ -18,7 +18,7 @@
   <div class="col-md-1 col-sm-2 col-xs-3">
     <div class="form-group" terrama2-show-errors>
       <label ng-bind="$ctrl.i18n.__('Delimiter')+':'"></label>
-      <input class="form-control" id="delimiter" name="delimiter" type="text" ng-model="$ctrl.csvFormatData.delimiter" ng-value="','" required>
+      <input class="form-control" id="delimiter" name="delimiter" type="text" ng-model="$ctrl.csvFormatData.delimiter" required>
     </div>
   </div>
 

--- a/webapp/public/javascripts/angular/wizard.html
+++ b/webapp/public/javascripts/angular/wizard.html
@@ -95,7 +95,7 @@
     <wz-step wz-title="{{ i18n.__('CSV Format') }}" canexit="validateSteps" wz-disabled="{{!custom_format}}" wz-data="wizard.csvFormat">
       <div class="col-md-12">
         <form name="forms.csvFormatForm">
-          <csv-format csv-format-data="csvFormatData" semantics="semantics"></csv-format>
+          <csv-format ng-if="csvFormatData.fields" csv-format-data="csvFormatData" semantics="semantics"></csv-format>
         </form>
       </div>
 


### PR DESCRIPTION
## Description:

Include a field `Delimiter` to customize CSV importation on database, since some of providers define **comma** or even **semicolon** on CSV files.

**Type:**

- [ ] New feature
- [x] Enhancement
- [ ] Bug

**Platform:**

- [x] Web
- [x] Linux
- [ ] Mac
- [ ] Windows

<details>
<summary><b>Changelog:<b/></summary>

*Enhancement:*
* Include CSV delimiter on semantics Occurrence CSV

</details>
