### PR TITLE
Add sentinel 2 in template maps - webmonitor

### DIFF
--- a/webmonitor/public/javascripts/TerraMA2WebMonitor.js
+++ b/webmonitor/public/javascripts/TerraMA2WebMonitor.js
@@ -857,6 +857,19 @@ define(
         LayerStatus.addLayerStatusIcon("gebco_08_grid");
       }
 
+      var sentinelURL = "https://b.s2maps-tiles.eu/wms?";
+      if(TerraMA2WebComponents.MapDisplay.addTileWMSLayer("s2cloudless", "Sentinel 2", "Sentinel 2", sentinelURL, "mapserver", false, false, "terrama2-layerexplorer", { version: "1.1.1", format: "image/jpeg" })){
+        TerraMA2WebComponents.LayerExplorer.addLayersFromMap("s2cloudless", "template", null, "treeview unsortable terrama2-truncate-text template", null);
+        var layerObject = Layers.createLayerObject({
+          layers: ["s2cloudless"],
+          name: "Senrinel 2",
+          type: "template",
+          description: null
+        });
+        Layers.addLayer(layerObject);
+        LayerStatus.addLayerStatusIcon("s2cloudless");
+      }
+
       addTreeviewMenuClass();
       LayerStatus.addGroupSpanIcon();
       Layers.addLayersToSort();


### PR DESCRIPTION
## Description:

Add sentinel 2 in template maps - webmonitor


**Type:**

- [ ] New feature
- [x] Enhancement
- [ ] Bug

**Platform:**

- [x] Web
- [x] Linux
- [ ] Mac
- [ ] Windows

<details>
<summary><b>Changelog:<b/></summary>

*Enhancement:*
* Add sentinel 2 in template maps - webmonitor

</details>
