### PR TITLE
Parameters of the analysis output image (Sample) and error messages

### DIFF
--- a/src/terrama2/services/analysis/core/GridContext.cpp
+++ b/src/terrama2/services/analysis/core/GridContext.cpp
@@ -124,13 +124,13 @@ te::gm::Coord2D terrama2::services::analysis::core::GridContext::convertoTo(cons
   return newPoint;
 }
 
-std::map<std::string, std::string> terrama2::services::analysis::core::GridContext::getOutputRasterInfo()
+std::map<std::string, double> terrama2::services::analysis::core::GridContext::getOutputRasterInfo()
 {
   if(outputRasterInfo_.empty())
   {
-    outputRasterInfo_["MEM_SRC_RASTER_DRIVER_TYPE"] = "GDAL";
-    outputRasterInfo_["MEM_RASTER_DATATYPE"] = te::common::Convert2String(te::dt::DOUBLE_TYPE);
-    outputRasterInfo_["MEM_RASTER_NBANDS"] = "1";
+    outputRasterInfo_["MEM_SRC_RASTER_DRIVER_TYPE"] = 1;//"GDAL";
+    outputRasterInfo_["MEM_RASTER_DATATYPE"] = te::dt::DOUBLE_TYPE;
+    outputRasterInfo_["MEM_RASTER_NBANDS"] = 1;
 
     if(!analysis_->outputGridPtr)
     {
@@ -138,29 +138,29 @@ std::map<std::string, std::string> terrama2::services::analysis::core::GridConte
       throw terrama2::InvalidArgumentException() << ErrorDescription(errMsg);
     }
 
-    outputRasterInfo_["MEM_RASTER_NODATA"] = std::to_string(analysis_->outputGridPtr->interpolationDummy);
+    outputRasterInfo_["MEM_RASTER_NODATA"] = analysis_->outputGridPtr->interpolationDummy;
     addInterestAreaToRasterInfo(outputRasterInfo_);
     addResolutionToRasterInfo(outputRasterInfo_);
 
-    auto resX = std::stod(outputRasterInfo_["MEM_RASTER_RES_X"]);
-    auto resY = std::stod(outputRasterInfo_["MEM_RASTER_RES_Y"]);
+    auto resX = outputRasterInfo_["MEM_RASTER_RES_X"];
+    auto resY = outputRasterInfo_["MEM_RASTER_RES_Y"];
 
-    auto minX = std::stod(outputRasterInfo_["MEM_RASTER_MIN_X"]);
-    auto minY = std::stod(outputRasterInfo_["MEM_RASTER_MIN_Y"]);
-    auto maxX = std::stod(outputRasterInfo_["MEM_RASTER_MAX_X"]);
-    auto maxY = std::stod(outputRasterInfo_["MEM_RASTER_MAX_Y"]);
+    auto minX = outputRasterInfo_["MEM_RASTER_MIN_X"];
+    auto minY = outputRasterInfo_["MEM_RASTER_MIN_Y"];
+    auto maxX = outputRasterInfo_["MEM_RASTER_MAX_X"];
+    auto maxY = outputRasterInfo_["MEM_RASTER_MAX_Y"];
 
     auto nRows = static_cast<unsigned int>(std::abs(std::ceil((maxY - minY) / resY)));
     auto nCols = static_cast<unsigned int>(std::abs(std::ceil((maxX - minX) / resX)));
 
-    outputRasterInfo_["MEM_RASTER_NROWS"] = std::to_string(nRows);
-    outputRasterInfo_["MEM_RASTER_NCOLS"] = std::to_string(nCols);
+    outputRasterInfo_["MEM_RASTER_NROWS"] = nRows;
+    outputRasterInfo_["MEM_RASTER_NCOLS"] = nCols;
   }
 
   return outputRasterInfo_;
 }
 
-void terrama2::services::analysis::core::GridContext::addResolutionToRasterInfo(std::map<std::string, std::string>& outputRasterInfo)
+void terrama2::services::analysis::core::GridContext::addResolutionToRasterInfo(std::map<std::string, double>& outputRasterInfo)
 {
   double resX = 0;
   double resY = 0;
@@ -321,11 +321,11 @@ void terrama2::services::analysis::core::GridContext::addResolutionToRasterInfo(
     throw terrama2::InvalidArgumentException() << ErrorDescription(errMsg);
   }
 
-  outputRasterInfo["MEM_RASTER_RES_X"] = std::to_string(resX);
-  outputRasterInfo["MEM_RASTER_RES_Y"] = std::to_string(resY);
+  outputRasterInfo["MEM_RASTER_RES_X"] = resX;
+  outputRasterInfo["MEM_RASTER_RES_Y"] = resY;
 }
 
-void terrama2::services::analysis::core::GridContext::addInterestAreaToRasterInfo(std::map<std::string, std::string>& outputRasterInfo)
+void terrama2::services::analysis::core::GridContext::addInterestAreaToRasterInfo(std::map<std::string, double>& outputRasterInfo)
 {
   Srid srid = 0;
   std::shared_ptr<te::gm::Envelope> box(new te::gm::Envelope());
@@ -364,14 +364,14 @@ void terrama2::services::analysis::core::GridContext::addInterestAreaToRasterInf
           if(srid == 0)
           {
             box->Union(*raster->getExtent());
-            srid = raster->getSRID();
+            srid = static_cast<Srid>(raster->getSRID());
             continue;
           }
 
           std::shared_ptr<te::gm::Geometry> geomBox(te::gm::GetGeomFromEnvelope(raster->getExtent(), raster->getSRID()));
           if(static_cast<Srid>(raster->getSRID()) != srid)
           {
-            geomBox->transform(srid);
+            geomBox->transform(static_cast<int>(srid));
           }
 
           box->Union(*geomBox->getMBR());
@@ -402,7 +402,7 @@ void terrama2::services::analysis::core::GridContext::addInterestAreaToRasterInf
         }
 
         box->Union(*raster->getExtent());
-        srid = raster->getSRID();
+        srid = static_cast<Srid>(raster->getSRID());
       }
       catch(const terrama2::core::NoDataException&)
       {
@@ -415,7 +415,7 @@ void terrama2::services::analysis::core::GridContext::addInterestAreaToRasterInf
     case InterestAreaType::CUSTOM:
     {
       box->Union(*analysis_->outputGridPtr->interestAreaBox->getMBR());
-      srid = analysis_->outputGridPtr->interestAreaBox->getSRID();
+      srid = static_cast<Srid>(analysis_->outputGridPtr->interestAreaBox->getSRID());
       break;
     }
   }
@@ -426,11 +426,12 @@ void terrama2::services::analysis::core::GridContext::addInterestAreaToRasterInf
     throw terrama2::InvalidArgumentException() << ErrorDescription(errMsg);
   }
 
-  terrama2::core::verify::srid(srid);
+  terrama2::core::verify::srid(static_cast<int>(srid));
 
-  outputRasterInfo["MEM_RASTER_SRID"] = std::to_string(srid);
-  outputRasterInfo["MEM_RASTER_MIN_X"] = std::to_string(box->getLowerLeftX());
-  outputRasterInfo["MEM_RASTER_MIN_Y"] = std::to_string(box->getLowerLeftY());
-  outputRasterInfo["MEM_RASTER_MAX_X"] = std::to_string(box->getUpperRightX());
-  outputRasterInfo["MEM_RASTER_MAX_Y"] = std::to_string(box->getUpperRightY());
+  outputRasterInfo["MEM_RASTER_SRID"] = srid;
+
+  outputRasterInfo["MEM_RASTER_MIN_X"] = box->getLowerLeftX();
+  outputRasterInfo["MEM_RASTER_MIN_Y"] = box->getLowerLeftY();
+  outputRasterInfo["MEM_RASTER_MAX_X"] = box->getUpperRightX();
+  outputRasterInfo["MEM_RASTER_MAX_Y"] = box->getUpperRightY();
 }

--- a/src/terrama2/services/analysis/core/GridContext.hpp
+++ b/src/terrama2/services/analysis/core/GridContext.hpp
@@ -91,12 +91,12 @@ namespace terrama2
 
           protected:
 
-            std::map<std::string, std::string> getOutputRasterInfo();
-            void addInterestAreaToRasterInfo(std::map<std::string, std::string>& outputRasterInfo);
-            void addResolutionToRasterInfo(std::map<std::string, std::string>& outputRasterInfo);
+            std::map<std::string, double> getOutputRasterInfo();
+            void addInterestAreaToRasterInfo(std::map<std::string, double>& outputRasterInfo);
+            void addResolutionToRasterInfo(std::map<std::string, double>& outputRasterInfo);
 
             std::shared_ptr<te::rst::Raster> outputRaster_;
-            std::map<std::string, std::string> outputRasterInfo_;
+            std::map<std::string, double> outputRasterInfo_;
         };
       }
     }

--- a/src/terrama2/services/analysis/core/dcp/zonal/Operator.cpp
+++ b/src/terrama2/services/analysis/core/dcp/zonal/Operator.cpp
@@ -192,12 +192,14 @@ double terrama2::services::analysis::core::dcp::zonal::operatorImpl(StatisticOpe
             catch(const std::out_of_range&)
             {
               QString errMsg(QObject::tr("DCP dataset does not have an alias."));
+              exceptionOccurred = true;
               throw InvalidDataSetException() << terrama2::ErrorDescription(errMsg);
             }
 
             if(dcpDataset->position == nullptr)
             {
               QString errMsg(QObject::tr("DCP dataset does not have a valid position."));
+              exceptionOccurred = true;
               throw InvalidDataSetException() << terrama2::ErrorDescription(errMsg);
             }
 
@@ -232,9 +234,10 @@ double terrama2::services::analysis::core::dcp::zonal::operatorImpl(StatisticOpe
                   continue;
                 values.push_back(value);
               }
-              catch(...)
+              catch(const terrama2::Exception& e)
               {
-                // In case the DCP doesn't have the specified column
+                context->addLogMessage(BaseContext::MessageType::ERROR_MESSAGE, boost::get_error_info<terrama2::ErrorDescription>(e)->toStdString());
+                exceptionOccurred = true;
                 continue;
               }
             }//end for syncDs

--- a/src/terrama2/services/analysis/core/utility/Utils.cpp
+++ b/src/terrama2/services/analysis/core/utility/Utils.cpp
@@ -188,35 +188,35 @@ terrama2::services::analysis::core::getGridMap(DataManagerPtr dataManager, DataS
 }
 
 std::tuple<te::rst::Grid*, const std::vector<te::rst::BandProperty*> >
-terrama2::services::analysis::core::getOutputRasterInfo(std::map<std::string, std::string> rinfo)
+terrama2::services::analysis::core::getOutputRasterInfo(std::map<std::string, double> rinfo)
 {
-  auto ncols = static_cast<uint>(std::stoi(rinfo["MEM_RASTER_NCOLS"]));
-  auto nrows = static_cast<uint>(std::stoi(rinfo["MEM_RASTER_NROWS"]));
-  auto srid = std::stoi(rinfo["MEM_RASTER_SRID"]);
+  auto ncols = static_cast<uint>(rinfo["MEM_RASTER_NCOLS"]);
+  auto nrows = static_cast<uint>(rinfo["MEM_RASTER_NROWS"]);
+  auto srid = rinfo["MEM_RASTER_SRID"];
 
-  double minx = std::stod(rinfo["MEM_RASTER_MIN_X"]);
-  double miny = std::stod(rinfo["MEM_RASTER_MIN_Y"]);
-  double maxx = std::stod(rinfo["MEM_RASTER_MAX_X"]);
-  double maxy = std::stod(rinfo["MEM_RASTER_MAX_Y"]);
-  double resx = std::stod(rinfo["MEM_RASTER_RES_X"]);
-  double resy = std::stod(rinfo["MEM_RASTER_RES_Y"]);
-  double nodata = std::stod(rinfo["MEM_RASTER_NODATA"]);
+  double minx = rinfo["MEM_RASTER_MIN_X"];
+  double miny = rinfo["MEM_RASTER_MIN_Y"];
+  double maxx = rinfo["MEM_RASTER_MAX_X"];
+  double maxy = rinfo["MEM_RASTER_MAX_Y"];
+  double resx = rinfo["MEM_RASTER_RES_X"];
+  double resy = rinfo["MEM_RASTER_RES_Y"];
+  double nodata = rinfo["MEM_RASTER_NODATA"];
 
   te::gm::Envelope* mbr = new te::gm::Envelope(minx, miny, maxx, maxy);
 
-  auto grid = new te::rst::Grid(ncols, nrows, resx, resy, mbr, srid);
+  auto grid = new te::rst::Grid(ncols, nrows, resx, resy, mbr, static_cast<int>(srid));
 
   std::vector<te::rst::BandProperty*> bands;
-  auto dt = std::stoi(rinfo["MEM_RASTER_DATATYPE"]);
-  std::size_t nbands = static_cast<std::size_t>(std::stoi(rinfo["MEM_RASTER_NBANDS"]));
+  auto dt = rinfo["MEM_RASTER_DATATYPE"];
+  std::size_t nbands = static_cast<std::size_t>(rinfo["MEM_RASTER_NBANDS"]);
   for(std::size_t b = 0; b < nbands; ++b)
   {
-    te::rst::BandProperty* ibprop = new te::rst::BandProperty(b, dt);
+    te::rst::BandProperty* ibprop = new te::rst::BandProperty(b, static_cast<int>(dt));
 
     ibprop->m_blkh = 1;
-    ibprop->m_blkw = ncols;
+    ibprop->m_blkw = static_cast<int>(ncols);
     ibprop->m_nblocksx = 1;
-    ibprop->m_nblocksy = nrows;
+    ibprop->m_nblocksy = static_cast<int>(nrows);
     ibprop->m_noDataValue = nodata;
 
     bands.push_back(ibprop);

--- a/src/terrama2/services/analysis/core/utility/Utils.cpp
+++ b/src/terrama2/services/analysis/core/utility/Utils.cpp
@@ -47,6 +47,7 @@
 #include <terralib/rp/Functions.h>
 #include <terralib/dataaccess/datasource/DataSourceFactory.h>
 #include <terralib/dataaccess/datasource/DataSourceTransactor.h>
+#include <terralib/datatype/Utils.h>
 
 // QT
 #include <QObject>
@@ -92,7 +93,7 @@ terrama2::services::analysis::core::AnalysisDataSeriesType terrama2::services::a
     case 4:
       return AnalysisDataSeriesType::ADDITIONAL_DATA_TYPE;
     default:
-      throw terrama2::InvalidArgumentException() << ErrorDescription(QObject::tr("Invalid analysis data series type"));
+      throw terrama2::InvalidArgumentException() << ErrorDescription(QObject::tr("Invalid analysis data series getInt64type"));
   }
 
 
@@ -259,7 +260,7 @@ double terrama2::services::analysis::core::getValue(terrama2::core::Synchronized
     }
     break;
     default:
-      break;
+      throw terrama2::InvalidArgumentException() << ErrorDescription( QObject::tr("Invalid property %1 with type %2").arg(QString::fromStdString(attribute.c_str())).arg(te::dt::ConvertDataTypeToString(attributeType).c_str()));
   }
 
   return value;

--- a/src/terrama2/services/analysis/core/utility/Utils.hpp
+++ b/src/terrama2/services/analysis/core/utility/Utils.hpp
@@ -146,7 +146,7 @@ namespace terrama2
 
           \return The map with the parameters to create the output raster.
          */
-        TMANALYSISEXPORT std::tuple<te::rst::Grid*, const std::vector<te::rst::BandProperty*> > getOutputRasterInfo(std::map<std::string, std::string> rinfo);
+        TMANALYSISEXPORT std::tuple<te::rst::Grid*, const std::vector<te::rst::BandProperty*> > getOutputRasterInfo(std::map<std::string, double> rinfo);
 
         /*!
           \brief Returns the attribute value for the given position, it tries a lexical cast to double in case the attribute has a different type.


### PR DESCRIPTION
## Description:
1.It was using string to store the values ​​of the parameters of creating a new grid, it was changed to use double. It was truncating the values, generating disagreements.
2.Settings in handling error messages.

## Reviewers:

@

**Type:**

- [ ] New feature
- [ ] Enhancement
- [X] Bug

**Platform:**

- [x] Web
- [x] Linux
- [ ] Mac
- [ ] Windows

<details>
<summary><b>Changelog:<b/></summary>

*New feature:*
* Item one
   * Sub item one

*Enhancement:*
* Item one
   * Sub item one

*Bug fix:*
* Item one
   * Sub item one

</details>
