### PR TITLE
Minor bug - force CollectorInputOutput on Collector instance when DCP updates

### DIFF
--- a/webapp/controllers/api/DataSeries.js
+++ b/webapp/controllers/api/DataSeries.js
@@ -279,8 +279,6 @@ module.exports = function(app) {
               collector.active = dataSeriesObject.input.active;
               collector.schedule_type = scheduleObject.scheduleType;
 
-              var updateSchedulePromise
-
               var oldScheduleType = collector.scheduleType;
               var newScheduleType = scheduleObject.scheduleType;
               var removeSchedule = false;
@@ -395,14 +393,17 @@ module.exports = function(app) {
                     ]);
                 })
                 // send via TCP
-                .then(function(dSeries) {
+                .then(async function(dSeries) {
                   const dataSeriesOutput = dSeries[0];
                   const dataSeriesInput = dSeries[1];
 
                   collector.project_id = request.session.activeProject.id;
+
+                  const updatedCollector = await DataManager.getCollector({ id: collector.id }, options);
+
                   const output = {
                     "DataSeries": [dataSeriesInput.toObject(), dataSeriesOutput.toObject()],
-                    "Collectors": [collector.toObject()]
+                    "Collectors": [updatedCollector.toObject()]
                   };
 
                   return output;

--- a/webapp/core/facade/Collector.js
+++ b/webapp/core/facade/Collector.js
@@ -47,11 +47,18 @@ class CollectorFacade {
       const found = currentListOfCollectorInOut.find(elm => elm.input_dataset === dataSet.id);
 
       if (!found) {
-        await CollectorInputOutput.create({
+        const inOut = {
           collector_id: collectorId,
           input_dataset: dataSet.id,
           output_dataset: outputDataSeries.dataSets[dataSetIndex].id
-        }, options)
+        };
+
+        await CollectorInputOutput.create(inOut, options);
+
+        currentListOfCollectorInOut.push(inOut);
+
+        // Refresh collector model elements
+        collector.setInputOutputMap(currentListOfCollectorInOut);
       }
     }
 


### PR DESCRIPTION
## Description:

Minor bug - force CollectorInputOutput on Collector instance when DCP updates

## Reviewers:

@hrgomesvieira 

**Type:**

- [ ] New feature
- [ ] Enhancement
- [x] Bug

**Platform:**

- [x] Web
- [x] Linux
- [ ] Mac
- [ ] Windows

<details>
<summary><b>Changelog:<b/></summary>

*Bug fix:*
* Minor bug - force CollectorInputOutput on Collector instance when DCP updates

</details>
