### PR TITLE
Fix merge with b4.1.1 - passing webmonitorHostConfig to browser

### DIFF
--- a/webmonitor/routes/index.js
+++ b/webmonitor/routes/index.js
@@ -10,11 +10,10 @@ module.exports = function(app) {
     var userConfig = Application.getContextConfig("user_conf");
 
     var webmonitorHostInfo = hostInfo.webmonitor;
-    var webadminHostInfo = hostInfo.webadmin;
     var message = {
       content: (req.query.message && req.query.message != "" ? req.query.message : "")
     };
-    res.render('index', { title: 'Express', message: message, userConfig: userConfig});
+    res.render('index', { title: 'Express', message: message, userConfig: userConfig, webmonitorHostInfo: webmonitorHostInfo });
   });
 
   app.post(app.locals.BASE_URL + 'languages', function(request, response) {


### PR DESCRIPTION
## Description:

Fix merge with b4.1.1 - passing ``webmonitorHostConfig`` to browser in order to avoid connect default port.

#1949 

## Reviewers:

@MarceloPilatti 

**Type:**

- [x] New feature
- [ ] Enhancement
- [ ] Bug

**Platform:**

- [x] Web
- [x] Linux
- [ ] Mac
- [ ] Windows

<details>
<summary><b>Changelog:<b/></summary>

*New feature:*
* Item one
   * Sub item one

*Enhancement:*
* Item one
   * Sub item one

*Bug fix:*
* Item one
   * Sub item one

</details>
