### PR TITLE
Removed prompt from ssh-keygen and fixed terralib tar.gz name on release-install.sh

### DIFF
--- a/install/release-install.sh
+++ b/install/release-install.sh
@@ -12,7 +12,7 @@ sudo apt-get update
 sudo apt-get install -y cmake libquazip-dev zip unzip screen openssh-server doxygen supervisor locales libgsasl7 postgresql-11-postgis-2.5 postgresql-server-dev-11 nodejs python-psycopg2 gdal-bin openjdk-8-jdk
 
 mkdir $HOME/.ssh
-ssh-keygen -t rsa -b 4096 -C "terrama2-team@dpi.inpe.br" -N "" -f $HOME/.ssh/id_rsa
+ssh-keygen -t rsa -b 4096 -C "terrama2-team@dpi.inpe.br" -N "" -f $HOME/.ssh/id_rsa <<< y
 
 mkdir terralib-installer
 cd terralib-installer
@@ -21,7 +21,7 @@ then
     wget -q http://www.dpi.inpe.br/jenkins-data/terrama2/3rdparty/terralib-5.4.5-ubuntu-16.04.tar.gz
 fi
 
-tar xf terralib-5.4.5-ubuntu-16.04_2019-12-13_15-45-5.4.5.tar.gz
+tar xf terralib-5.4.5-ubuntu-16.04.tar.gz
 ./install.sh
 
 cd ..


### PR DESCRIPTION
## Description:

Removed prompt from ssh-keygen and fixed terralib tar.gz name on release-install.sh

## Reviewers:

@juan0101 

**Type:**

- [ ] New feature
- [x] Enhancement
- [x] Bug

**Platform:**

- [x] Web
- [x] Linux
- [ ] Mac
- [ ] Windows

<details>
<summary><b>Changelog:<b/></summary>

*New feature:*
* Item one
   * Sub item one

*Enhancement:*
* Item one
   * Sub item one

*Bug fix:*
* Item one
   * Sub item one

</details>
